### PR TITLE
Add utilities so that `freud.diffraction.Diffractometer` can be used like bitbucket diffractometer code

### DIFF
--- a/cmeutils/__init__.py
+++ b/cmeutils/__init__.py
@@ -1,4 +1,4 @@
-from . import gsd_utils
+from . import gsd_utils, structure
 from .__version__ import __version__
 
-__all__ = ["__version__", "gsd_utils"]
+__all__ = ["__version__", "gsd_utils", "structure"]

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -8,7 +8,27 @@ from cmeutils import gsd_utils
 
 
 def get_quaternions(n_views = 20):
-    """Get the quaternions for the specified number of views."""
+    """Get the quaternions for the specified number of views.
+
+    The first (n_view - 3) views will be the views even distributed on a sphere,
+    while the last three views will be the face-on, edge-on, and corner-on
+    views, respectively.
+
+    These quaternions are useful as input to `view_orientation` kwarg in
+    `freud.diffraction.Diffractometer.compute`.
+
+    Parameters
+    ----------
+    n_views : int, default 20
+        The number of views to compute.
+
+    Returns
+    -------
+    list of numpy.ndarray
+        Quaternions as (4,) arrays.
+    """
+    if n_views <=3 or not isinstance(n_views, int):
+        raise ValueError("Please set n_views to an integer greater than 3.")
     # Calculate points for even distribution on a sphere
     ga = np.pi * (3 - 5**0.5)
     theta = ga * np.arange(n_views-3)

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -14,7 +14,7 @@ def rotmat_to_q(m):
     return np.array([qx, qy, qz, qw])
 
 def rotation_matrix_from_to(a, b):
-    """Compute a rotation matrix R such that norm(b)*dot(R,a)/norm(a) = b.
+    """Compute a rotation matrix, R, such that norm(b) * dot(R,a) / norm(a) = b.
 
     Parameters
     ----------

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -1,21 +1,15 @@
-from cmeutils import gsd_utils
 import freud
 import gsd
 import gsd.hoomd
 import numpy as np
+from rowan import vector_vector_rotation
 
-
-def q_from_vectors(b, a=np.array([0,0,1])):
-    """Calculate the quaternion representing the rotation from a to b."""
-    q = np.empty(4)
-    q[:3] = np.cross(a,b)
-    q[3] = np.dot(a,b)
-    q /= np.linalg.norm(q)
-    return q
+from cmeutils import gsd_utils
 
 
 def get_quaternions(n_views = 20):
     """Get the quaternions for the specified number of views."""
+    # Calculate points for even distribution on a sphere
     ga = np.pi * (3 - 5**0.5)
     theta = ga * np.arange(n_views-3)
     z = np.linspace(1 - 1/(n_views-3), 1/(n_views-3), n_views-3)
@@ -24,13 +18,16 @@ def get_quaternions(n_views = 20):
     points[:-3,0] = radius * np.cos(theta)
     points[:-3,1] = radius * np.sin(theta)
     points[:-3,2] = z
+
     # face on
-    points[-3] = np.array([0,0,1])
+    points[-3] = np.array([0, 0, 1])
     # edge on
-    points[-2] = np.array([0,1,1])
+    points[-2] = np.array([0, 1, 1])
     # corner on
-    points[-1] = np.array([1,1,1])
-    return [q_from_vectors(i) for i in points]
+    points[-1] = np.array([1, 1, 1])
+
+    unit_z = np.array([0, 0, 1])
+    return [vector_vector_rotation(i, unit_z) for i in points]
 
 
 def gsd_rdf(

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -5,6 +5,67 @@ import gsd.hoomd
 import numpy as np
 
 
+def rotmat_to_q(m):
+    """Convert a 3x3 rotation matrix to a quaternion."""
+    qw = np.sqrt(1 + m[0,0] + m[1,1] + m[2,2]) / 2
+    qx = (m[2,1] - m[1,2])/(4 * qw)
+    qy = (m[0,2] - m[2,0])/(4 * qw)
+    qz = (m[1,0] - m[0,1])/(4 * qw)
+    return np.array([qx, qy, qz, qw])
+
+def rotation_matrix_from_to(a, b):
+    """Compute a rotation matrix R such that norm(b)*dot(R,a)/norm(a) = b.
+
+    Parameters
+    ----------
+    a : numpy.ndarray
+        A 3-vector
+    b : numpy.ndarray
+        Another 3-vector
+
+    Returns:
+    R numpy.ndarray:
+        The 3x3 rotation matrix that will would rotate a parallel to b.
+    """
+    a1 = a/np.linalg.norm(a)
+    b1 = b/np.linalg.norm(b)
+    theta = np.arccos(np.dot(a1,b1))
+    if theta<1e-6 or np.isnan(theta):
+        return np.identity(3)
+    if np.pi-theta<1e-6: #TODO(Eric): verify correct
+        d = np.array([1.,0,0])
+        x = np.cross(a1,d)
+    else:
+        x = np.cross(a1,b1)
+        x /= np.linalg.norm(x)
+    A = np.array([ [0,-x[2],x[1]], [x[2],0,-x[0]], [-x[1],x[0],0] ])
+    R = np.identity(3) + np.sin(theta)*A + (1.-np.cos(theta))*np.dot(A,A)
+    return R
+
+def get_rotmats(n_views = 20):
+    """Get the rotation matrices for the specified number of views."""
+    ga = np.pi * (3 - 5**0.5)
+    theta = ga * np.arange(n_views-3)
+    z = np.linspace(1 - 1/(n_views-3), 1/(n_views-3), n_views-3)
+    radius = np.sqrt(1 - z * z)
+    points = np.zeros((n_views, 3))
+    points[:-3,0] = radius * np.cos(theta)
+    points[:-3,1] = radius * np.sin(theta)
+    points[:-3,2] = z
+    # face on
+    points[-3] = np.array([0,0,1])
+    # edge on
+    points[-2] = np.array([0,1,1])
+    # corner on
+    points[-1] = np.array([1,1,1])
+    return [rotation_matrix_from_to(i,np.array([0,0,1])) for i in points]
+
+def get_quaternions(n_views = 20):
+    """Get the quaternions for the specified number of views."""
+    rotmats = get_rotmats(n_views = n_views)
+    return [rotmat_to_q(i) for i in rotmats]
+
+
 def gsd_rdf(
     gsdfile,
     A_name,

--- a/cmeutils/tests/test_structure.py
+++ b/cmeutils/tests/test_structure.py
@@ -1,5 +1,7 @@
 import pytest
 
+import numpy as np
+
 from cmeutils.tests.base_test import BaseTest
 
 
@@ -10,7 +12,7 @@ class TestStructure(BaseTest):
         rdf_ex, norm = gsd_rdf(gsdfile_bond, "A", "B")
         rdf_noex, norm2 = gsd_rdf(gsdfile_bond, "A", "B", exclude_bonded=False)
         assert norm2 == 1
-        assert rdf_noex != rdf_ex
+        assert not np.array_equal(rdf_noex, rdf_ex)
 
     def test_gsd_rdf_samename(self, gsdfile_bond):
         from cmeutils.structure import gsd_rdf
@@ -18,4 +20,17 @@ class TestStructure(BaseTest):
         rdf_ex, norm = gsd_rdf(gsdfile_bond, "A", "A")
         rdf_noex, norm2 = gsd_rdf(gsdfile_bond, "A", "A", exclude_bonded=False)
         assert norm2 == 1
-        assert rdf_noex != rdf_ex
+        assert not np.array_equal(rdf_noex, rdf_ex)
+
+    def test_get_quaternions(self):
+        from cmeutils.structure import get_quaternions
+
+        with pytest.raises(ValueError):
+            get_quaternions(0)
+
+        with pytest.raises(ValueError):
+            get_quaternions(5.3)
+
+        qs = get_quaternions()
+        assert len(qs) == 20
+        assert len(qs[0]) == 4

--- a/environment.yml
+++ b/environment.yml
@@ -9,3 +9,4 @@ dependencies:
   - python=3.7
   - pytest
   - pytest-cov
+  - rowan

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - numpy
   - pip
   - python=3.7
+  - matplotlib
   - pytest
   - pytest-cov
   - rowan


### PR DESCRIPTION
The `compute` method for rhe `freud.diffraction.Diffractomer` class takes a quaternion as the [view_orientation kwarg](https://freud.readthedocs.io/en/latest/modules/diffraction.html#freud.diffraction.DiffractionPattern.compute). In order to use this module the same way the old diffractometer code was used, we need to convert the rotation matrices to quaternions.
- ~`rotmat_to_q` calculation follows [this example](http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/).~
- `get_quaternions` uses similar logic to get the view vectors as `prep_matrices` from bitbucket `cme_utils/analyze/diffractometer.py` 
- ~`rotation_matrix_from_to` is from bitbucket `cme_utils/manip/utilities.py` (only docstring formatting has been updated.)~
- Bradley Dice in the glotzer group helped immensely with solving this issue. https://github.com/glotzerlab/freud/issues/792

Thoughts/TODO
- [x] should this go here or in gixstapose? -- Now that it is so simple, I think here.
- [x] needs unit tests