### PR TITLE
Create dynamics.py with Freud MSD functionality

### DIFF
--- a/cmeutils/__init__.py
+++ b/cmeutils/__init__.py
@@ -1,4 +1,4 @@
 from . import gsd_utils, structure
 from .__version__ import __version__
 
-__all__ = ["__version__", "gsd_utils", "structure"]
+__all__ = ["__version__", "gsd_utils", "structure", "dynamics"]

--- a/cmeutils/dynamics.py
+++ b/cmeutils/dynamics.py
@@ -40,6 +40,6 @@ def msd_from_gsd(
             images.append(atom_img)
 
         msd = freud.msd.MSD(box=init_box, mode=msd_mode)
-        msd.compute(np.array(positions), reset=False)
+        msd.compute(np.array(positions), np.array(images), reset=False)
     return msd
  

--- a/cmeutils/dynamics.py
+++ b/cmeutils/dynamics.py
@@ -31,7 +31,12 @@ def msd_from_gsd(
             else:
                 atom_pos = gsd_utils.get_type_position(atom_types, snap=frame)
             positions.append(atom_pos)
-        msd = freud.msd.MSD(box=init_box, mode=msd_mode)
+        freud_box = freud.Box(
+                Lx=init_box[0],
+                Ly=init_box[1],
+                Lz=init_box[2]
+                )
+        msd = freud.msd.MSD(box=freud_box, mode=msd_mode)
         msd.compute(np.array(positions), reset=False)
     return msd
  

--- a/cmeutils/dynamics.py
+++ b/cmeutils/dynamics.py
@@ -10,7 +10,7 @@ def msd_from_gsd(
         gsdfile,
         atom_types="all",
         start=0,
-        stop=None,
+        stop=-1,
         msd_mode="window"
         ):
     """Calculate the mean-square displacement (MSD) of the particles in a
@@ -32,9 +32,6 @@ def msd_from_gsd(
         Choose from "window" or "direct". See Freud for the differences
         https://freud.readthedocs.io/en/latest/modules/msd.html#freud.msd.MSD
     """
-    if stop is None:
-        stop = -1
-
     with gsd.hoomd.open(gsdfile, "rb") as trajectory:
         init_box = trajectory[start].configuration.box
         final_box = trajectory[stop].configuration.box

--- a/cmeutils/dynamics.py
+++ b/cmeutils/dynamics.py
@@ -13,7 +13,24 @@ def msd_from_gsd(
         stop=None,
         msd_mode="window"
         ):
-    """
+    """Calculate the mean-square displacement (MSD) of the particles in a
+    trajectory using Freud.
+
+    Parameters
+    ----------
+    gsdfile : str
+        Filename of the GSD trajectory
+    atom_types : str, or list of str
+        Name(s) of particles to use in calcualtion of the MSD
+    start : int
+        The first frame from the gsd file to use
+        (default 0)
+    stop : int
+        The last frame from the gsd file to use
+        (default -1)
+    msd_mode : str
+        Choose from "window" or "direct". See Freud for the differences
+        https://freud.readthedocs.io/en/latest/modules/msd.html#freud.msd.MSD
     """
     if stop is None:
         stop = -1

--- a/cmeutils/dynamics.py
+++ b/cmeutils/dynamics.py
@@ -1,0 +1,36 @@
+import freud
+import gsd
+import gsd.hoomd
+import numpy as np
+
+from cmeutils import gsd_utils
+
+def msd_from_gsd(
+        gsdfile,
+        atom_types,
+        start=0,
+        stop=None,
+        msd_mode="window"
+        ):
+    """
+    """
+    if stop is None:
+        stop = -1
+    with gsd.hoomd.open(gsdfile, "rb") as trajectory:
+        assert(
+                trajectory[start].configuration.box == 
+                trajectory[stop].configuration.box
+                ), f"The box is not consistent over the range{start}:{stop}"
+
+        frame_positions = []
+        for frame in trajectory[start:stop]:
+            if atom_type == "all":
+                atom_pos = frame.particles.position[:]
+            else:
+                atom_pos = gsd_utils.get_type_position(atom_types, snap=frame)
+            frame_positions.append(atom_pos)
+
+        msd = freud.msd.MSD(box=trajectory.configuration.box, mode=msd_mode)
+        msd.compute(positions)
+    return msd.msd
+ 

--- a/cmeutils/dynamics.py
+++ b/cmeutils/dynamics.py
@@ -23,6 +23,7 @@ def msd_from_gsd(
         assert all(
                 [i == j for i,j in zip(init_box, final_box)]
                 ), f"The box is not consistent over the range {start}:{stop}"
+
         positions = []
         for frame in trajectory[start:stop]:
             if atom_types == "all":
@@ -30,8 +31,7 @@ def msd_from_gsd(
             else:
                 atom_pos = gsd_utils.get_type_position(atom_types, snap=frame)
             positions.append(atom_pos)
-
         msd = freud.msd.MSD(box=init_box, mode=msd_mode)
-        msd.compute(positions)
-    return msd.msd
+        msd.compute(np.array(positions), reset=False)
+    return msd
  

--- a/cmeutils/dynamics.py
+++ b/cmeutils/dynamics.py
@@ -25,18 +25,21 @@ def msd_from_gsd(
                 ), f"The box is not consistent over the range {start}:{stop}"
 
         positions = []
+        images = []
         for frame in trajectory[start:stop]:
             if atom_types == "all":
                 atom_pos = frame.particles.position[:]
+                atom_img = frame.particles.image[:]
             else:
-                atom_pos = gsd_utils.get_type_position(atom_types, snap=frame)
-            positions.append(atom_pos)
-        freud_box = freud.Box(
-                Lx=init_box[0],
-                Ly=init_box[1],
-                Lz=init_box[2]
+                atom_pos, atom_img  = gsd_utils.get_type_position(
+                            atom_types,
+                            snap=frame,
+                            images=True
                 )
-        msd = freud.msd.MSD(box=freud_box, mode=msd_mode)
+            positions.append(atom_pos)
+            images.append(atom_img)
+
+        msd = freud.msd.MSD(box=init_box, mode=msd_mode)
         msd.compute(np.array(positions), reset=False)
     return msd
  

--- a/cmeutils/dynamics.py
+++ b/cmeutils/dynamics.py
@@ -7,7 +7,7 @@ from cmeutils import gsd_utils
 
 def msd_from_gsd(
         gsdfile,
-        atom_types,
+        atom_types="all",
         start=0,
         stop=None,
         msd_mode="window"

--- a/cmeutils/dynamics.py
+++ b/cmeutils/dynamics.py
@@ -2,6 +2,7 @@ import freud
 import gsd
 import gsd.hoomd
 import numpy as np
+from warnings import warn
 
 from cmeutils import gsd_utils
 
@@ -38,7 +39,12 @@ def msd_from_gsd(
                 )
             positions.append(atom_pos)
             images.append(atom_img)
-
+        if np.count_nonzero(np.array(images)) == 0:
+            warn(
+                f"All of the images over the range {start}-{stop} "
+                "are [0,0,0]. You may want to ensure this gsd file "
+                "had the particle images written to it."
+                )
         msd = freud.msd.MSD(box=init_box, mode=msd_mode)
         msd.compute(np.array(positions), np.array(images), reset=False)
     return msd

--- a/cmeutils/gsd_utils.py
+++ b/cmeutils/gsd_utils.py
@@ -4,7 +4,12 @@ import gsd.hoomd
 import numpy as np
 
 
-def get_type_position(typename, gsd_file=None, snap=None, gsd_frame=-1):
+def get_type_position(
+        typename,
+        gsd_file=None,
+        snap=None,
+        gsd_frame=-1
+        images=False):
     """
     This function returns the  positions of a particular particle
     type from a frame of a gsd trajectory file or from a snapshot.
@@ -23,22 +28,36 @@ def get_type_position(typename, gsd_file=None, snap=None, gsd_frame=-1):
         Trajectory snapshot
     gsd_frame : int, default -1
         Frame number to get positions from. Supports negative indexing.
+    images : bool, default False
+        If True; an array of the particle images is returned in addition
+        to the particle positions.
 
     Returns
     -------
-    numpy.ndarray
+    numpy.ndarray(s)
     """
     snap = _validate_inputs(gsd_file, snap, gsd_frame)
     if isinstance(typename, str):
         typename = [typename]
-    typepos = []
+
+    type_pos = []
+    type_images = []
     for _type in typename:
-        typepos.extend(
+        type_pos.extend(
                 snap.particles.position[
                 snap.particles.typeid == snap.particles.types.index(_type)
             ]
         )
-    return np.array(typepos)
+        if images:
+            type_images.extend(
+                snap.particles.image[
+                    snap.particles.typeid == snap.particles.types.index(_type)
+                ]
+            )
+    if images:
+        return np.array(typepos), np.array(images)
+    else:
+        return np.array(typepos)
 
 
 def get_all_types(gsd_file=None, snap=None, gsd_frame=-1):

--- a/cmeutils/gsd_utils.py
+++ b/cmeutils/gsd_utils.py
@@ -12,9 +12,11 @@ def get_type_position(typename, gsd_file=None, snap=None, gsd_frame=-1):
 
     Parameters
     ----------
-    typename : str,
+    typename : str or list of str
         Name of particles of which to get the positions
         (found in gsd.hoomd.Snapshot.particles.types)
+        If you want the positions of multiple types, pass
+        in a list. Ex.) ['ca', 'c3']
     gsd_file : str, default None
         Filename of the gsd trajectory
     snap : gsd.hoomd.Snapshot, default None
@@ -27,10 +29,16 @@ def get_type_position(typename, gsd_file=None, snap=None, gsd_frame=-1):
     numpy.ndarray
     """
     snap = _validate_inputs(gsd_file, snap, gsd_frame)
-    typepos = snap.particles.position[
-        snap.particles.typeid == snap.particles.types.index(typename)
-    ]
-    return typepos
+    if isinstance(typename, str):
+        typename = [typename]
+    typepos = []
+    for _type in typename:
+        typepos.extend(
+                snap.particles.position[
+                snap.particles.typeid == snap.particles.types.index(_type)
+            ]
+        )
+    return np.array(typepos)
 
 
 def get_all_types(gsd_file=None, snap=None, gsd_frame=-1):

--- a/cmeutils/gsd_utils.py
+++ b/cmeutils/gsd_utils.py
@@ -55,9 +55,9 @@ def get_type_position(
                 ]
             )
     if images:
-        return np.array(typepos), np.array(images)
+        return np.array(type_pos), np.array(images)
     else:
-        return np.array(typepos)
+        return np.array(type_pos)
 
 
 def get_all_types(gsd_file=None, snap=None, gsd_frame=-1):

--- a/cmeutils/gsd_utils.py
+++ b/cmeutils/gsd_utils.py
@@ -35,6 +35,8 @@ def get_type_position(
     Returns
     -------
     numpy.ndarray(s)
+        Retruns a single array of positions or
+        arrays of positions and images
     """
     snap = _validate_inputs(gsd_file, snap, gsd_frame)
     if isinstance(typename, str):

--- a/cmeutils/gsd_utils.py
+++ b/cmeutils/gsd_utils.py
@@ -57,7 +57,7 @@ def get_type_position(
                 ]
             )
     if images:
-        return np.array(type_pos), np.array(images)
+        return np.array(type_pos), np.array(type_images)
     else:
         return np.array(type_pos)
 

--- a/cmeutils/gsd_utils.py
+++ b/cmeutils/gsd_utils.py
@@ -8,7 +8,7 @@ def get_type_position(
         typename,
         gsd_file=None,
         snap=None,
-        gsd_frame=-1
+        gsd_frame=-1,
         images=False):
     """
     This function returns the  positions of a particular particle

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -55,7 +55,7 @@ def gsd_rdf(
     A_name,
     B_name,
     start=0,
-    stop=None,
+    stop=-1,
     r_max=None,
     r_min=0,
     bins=100,
@@ -82,10 +82,10 @@ def gsd_rdf(
         from the end. (default 0)
     stop : int
         Final frame index for accumulating the RDF. If None, the last frame
-        will be used. (default None)
+        will be used. (default -1)
     r_max : float
         Maximum radius of RDF. If None, half of the maximum box size is used.
-        (default None)
+        (default -1)
     r_min : float
         Minimum radius of RDF. (default 0)
     bins : int

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -98,9 +98,6 @@ def gsd_rdf(
     -------
     (freud.density.RDF, float)
     """
-    if not stop:
-        stop = -1
-
     with gsd.hoomd.open(gsdfile, mode="rb") as trajectory:
         snap = trajectory[0]
 

--- a/cmeutils/tests/base_test.py
+++ b/cmeutils/tests/base_test.py
@@ -20,13 +20,19 @@ class BaseTest:
         return filename
 
     @pytest.fixture
+    def gsdfile_images(self, tmp_path):
+        filename = tmp_path / "test_images.gsd"
+        create_gsd(filename, images=True)
+        return filename
+
+    @pytest.fixture
     def snap(self, gsdfile):
         with gsd.hoomd.open(name=gsdfile, mode="rb") as f:
             snap = f[-1]
         return snap
 
 
-def create_frame(i, add_bonds, seed=42):
+def create_frame(i, add_bonds, images, seed=42):
     np.random.seed(seed)
     s = gsd.hoomd.Snapshot()
     s.configuration.step = i
@@ -40,10 +46,14 @@ def create_frame(i, add_bonds, seed=42):
         s.bonds.types = ["AB"]
         s.bonds.typeid = [0, 0]
         s.bonds.group = [[0, 2], [1, 3]]
+    if images:
+        s.particles.image = np.full(shape=(5,3), fill_value=i)
+    else:
+        s.particles.image = np.zeros(shape=(5,3))
     s.validate()
     return s
 
 
-def create_gsd(filename, add_bonds=False):
+def create_gsd(filename, add_bonds=False, images=False):
     with gsd.hoomd.open(name=filename, mode="wb") as f:
-        f.extend((create_frame(i, add_bonds=add_bonds) for i in range(10)))
+        f.extend((create_frame(i, add_bonds=add_bonds, images=images) for i in range(10)))

--- a/cmeutils/tests/test_dynamics.py
+++ b/cmeutils/tests/test_dynamics.py
@@ -1,0 +1,9 @@
+import pytest
+
+from cmeutils.tests.base_test import BaseTest
+from cmeutils.dynamics import msd_from_gsd
+
+class TestDynamics(BaseTest):
+    def test_gsd_msd(self, gsdfile):
+        msd_window = msd_from_gsd(gsdfile)
+        msd_direct = msd_from_gsd(gsdfile, msd_mode="direct")

--- a/cmeutils/tests/test_dynamics.py
+++ b/cmeutils/tests/test_dynamics.py
@@ -4,6 +4,10 @@ from cmeutils.tests.base_test import BaseTest
 from cmeutils.dynamics import msd_from_gsd
 
 class TestDynamics(BaseTest):
-    def test_gsd_msd(self, gsdfile):
-        msd_window = msd_from_gsd(gsdfile)
-        msd_direct = msd_from_gsd(gsdfile, msd_mode="direct")
+    def test_gsd_msd(self, gsdfile_images):
+        msd_window = msd_from_gsd(gsdfile_images)
+        msd_direct = msd_from_gsd(gsdfile_images, msd_mode="direct")
+
+    def test_gsd_no_images(self, gsdfile):
+        with pytest.warns(UserWarning):
+            msd = msd_from_gsd(gsdfile)

--- a/cmeutils/tests/test_gsd.py
+++ b/cmeutils/tests/test_gsd.py
@@ -17,6 +17,12 @@ class TestGSD(BaseTest):
         assert type(pos_array) is type(np.array([]))
         assert pos_array.shape == (5,3)
 
+    def test_get_position_and_images(self, gsdfile_images):
+        from cmeutils.gsd_utils import get_type_position
+        pos, imgs = get_type_position(gsd_file=gsdfile_images, typename="A")
+        assert type(pos) is type(imgs) is type(np.array([]))
+        assert pos.shape == imgs.shape
+
     def test_validate_inputs(self, gsdfile, snap):
         from cmeutils.gsd_utils import _validate_inputs
 

--- a/cmeutils/tests/test_gsd.py
+++ b/cmeutils/tests/test_gsd.py
@@ -2,30 +2,27 @@ import numpy as np
 import pytest
 
 from base_test import BaseTest
+from cmeutils.gsd_utils import get_type_position, snap_molecule_cluster
+from cmeutils.gsd_utils import get_all_types, _validate_inputs
 
 
 class TestGSD(BaseTest):
     def test_get_type_position(self, gsdfile):
-        from cmeutils.gsd_utils import get_type_position
         pos_array = get_type_position(gsd_file=gsdfile, typename="A")
         assert type(pos_array) is type(np.array([]))
         assert pos_array.shape == (2, 3)
 
     def test_get_multiple_types(self, gsdfile):
-        from cmeutils.gsd_utils import get_type_position
         pos_array = get_type_position(gsd_file=gsdfile, typename=["A", "B"])
         assert type(pos_array) is type(np.array([]))
         assert pos_array.shape == (5,3)
 
     def test_get_position_and_images(self, gsdfile_images):
-        from cmeutils.gsd_utils import get_type_position
         pos, imgs = get_type_position(gsd_file=gsdfile_images, typename="A")
         assert type(pos) is type(imgs) is type(np.array([]))
         assert pos.shape == imgs.shape
 
     def test_validate_inputs(self, gsdfile, snap):
-        from cmeutils.gsd_utils import _validate_inputs
-
         # Catch errors when both gsd_file and snap are passed
         with pytest.raises(ValueError):
             _validate_inputs(gsdfile, snap, 1)
@@ -37,13 +34,9 @@ class TestGSD(BaseTest):
             _validate_inputs("bad_gsd_file", None, 0)
 
     def test_get_all_types(self, gsdfile):
-        from cmeutils.gsd_utils import get_all_types
-
         types = get_all_types(gsdfile)
         assert types == ["A", "B"]
 
     def test_snap_molecule_cluster(self, gsdfile_bond):
-        from cmeutils.gsd_utils import snap_molecule_cluster
-
         cluster = snap_molecule_cluster(gsd_file=gsdfile_bond)
         assert np.array_equal(cluster, [0, 1, 0, 1, 2])

--- a/cmeutils/tests/test_gsd.py
+++ b/cmeutils/tests/test_gsd.py
@@ -7,10 +7,15 @@ from base_test import BaseTest
 class TestGSD(BaseTest):
     def test_get_type_position(self, gsdfile):
         from cmeutils.gsd_utils import get_type_position
-
         pos_array = get_type_position(gsd_file=gsdfile, typename="A")
         assert type(pos_array) is type(np.array([]))
         assert pos_array.shape == (2, 3)
+
+    def test_get_multiple_types(self, gsdfile):
+        from cmeutils.gsd_utils import get_type_position
+        pos_array = get_type_position(gsd_file=gsdfile, typename=["A", "B"])
+        assert type(pos_array) is type(np.array([]))
+        assert pos_array.shape == (5,3)
 
     def test_validate_inputs(self, gsdfile, snap):
         from cmeutils.gsd_utils import _validate_inputs

--- a/cmeutils/tests/test_gsd.py
+++ b/cmeutils/tests/test_gsd.py
@@ -18,7 +18,11 @@ class TestGSD(BaseTest):
         assert pos_array.shape == (5,3)
 
     def test_get_position_and_images(self, gsdfile_images):
-        pos, imgs = get_type_position(gsd_file=gsdfile_images, typename="A")
+        pos, imgs = get_type_position(
+                gsd_file=gsdfile_images,
+                typename="A",
+                images=True
+                )
         assert type(pos) is type(imgs) is type(np.array([]))
         assert pos.shape == imgs.shape
 

--- a/cmeutils/tests/test_structure.py
+++ b/cmeutils/tests/test_structure.py
@@ -3,28 +3,22 @@ import pytest
 import numpy as np
 
 from cmeutils.tests.base_test import BaseTest
-
+from cmeutils.structure import gsd_rdf, get_quaternions
 
 class TestStructure(BaseTest):
     def test_gsd_rdf(self, gsdfile_bond):
-        from cmeutils.structure import gsd_rdf
-
         rdf_ex, norm = gsd_rdf(gsdfile_bond, "A", "B")
         rdf_noex, norm2 = gsd_rdf(gsdfile_bond, "A", "B", exclude_bonded=False)
         assert norm2 == 1
         assert not np.array_equal(rdf_noex, rdf_ex)
 
     def test_gsd_rdf_samename(self, gsdfile_bond):
-        from cmeutils.structure import gsd_rdf
-
         rdf_ex, norm = gsd_rdf(gsdfile_bond, "A", "A")
         rdf_noex, norm2 = gsd_rdf(gsdfile_bond, "A", "A", exclude_bonded=False)
         assert norm2 == 1
         assert not np.array_equal(rdf_noex, rdf_ex)
 
     def test_get_quaternions(self):
-        from cmeutils.structure import get_quaternions
-
         with pytest.raises(ValueError):
             get_quaternions(0)
 


### PR DESCRIPTION
This PR puts the MSD from GSD functionality that we have floating around in various notebooks and python files into a single location.  

Also, I updated `get_type_position` to accept a list (or iterable) of atom types and return their positions as opposed to only accepting a single atom type.  I think this will offer more flexibility.

Still needs unit tests and doc strings, but I figured I'd put it up here for others to comment on.