### PR TITLE
Fix RDF normalization when type A and B are different

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Other stuff
+*.gsd

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -147,7 +147,9 @@ def gsd_rdf(
             rdf.compute(aq, neighbors=nlist, reset=False)
 
         normalization = post_filter / pre_filter if exclude_bonded else 1
-        return rdf, normalization, ab_ratio
+        normalization *= ab_ratio
+
+        return rdf, normalization
 
 
 def get_centers(gsdfile, new_gsdfile):

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -123,9 +123,11 @@ def gsd_rdf(
             if A_name == B_name:
                 B_pos = A_pos
                 exclude_ii = True
+                ab_ratio = 1
             else:
                 B_pos = snap.particles.position[type_B]
                 exclude_ii = False
+                ab_ratio = len(A_pos) / len(B_pos)
 
             box = snap.configuration.box
             system = (box, A_pos)
@@ -145,7 +147,7 @@ def gsd_rdf(
             rdf.compute(aq, neighbors=nlist, reset=False)
 
         normalization = post_filter / pre_filter if exclude_bonded else 1
-        return rdf, normalization
+        return rdf, normalization, ab_ratio
 
 
 def get_centers(gsdfile, new_gsdfile):

--- a/cmeutils/tests/test_structure.py
+++ b/cmeutils/tests/test_structure.py
@@ -13,7 +13,7 @@ class TestStructure(BaseTest):
     def test_gsd_rdf(self, gsdfile_bond):
         rdf_ex, norm = gsd_rdf(gsdfile_bond, "A", "B")
         rdf_noex, norm2 = gsd_rdf(gsdfile_bond, "A", "B", exclude_bonded=False)
-        assert norm2 == 1
+        assert np.round(norm2, 3) == np.round(2/3, 3)
         assert not np.array_equal(rdf_noex, rdf_ex)
 
     def test_gsd_rdf_samename(self, gsdfile_bond):

--- a/cmeutils/tests/test_structure.py
+++ b/cmeutils/tests/test_structure.py
@@ -13,7 +13,7 @@ class TestStructure(BaseTest):
     def test_gsd_rdf(self, gsdfile_bond):
         rdf_ex, norm = gsd_rdf(gsdfile_bond, "A", "B")
         rdf_noex, norm2 = gsd_rdf(gsdfile_bond, "A", "B", exclude_bonded=False)
-        assert np.round(norm2, 3) == np.round(2/3, 3)
+        assert np.isclose(norm2, 2/3, 1e-4)
         assert not np.array_equal(rdf_noex, rdf_ex)
 
     def test_gsd_rdf_samename(self, gsdfile_bond):

--- a/cmeutils/tests/test_structure.py
+++ b/cmeutils/tests/test_structure.py
@@ -22,6 +22,15 @@ class TestStructure(BaseTest):
         assert norm2 == 1
         assert not np.array_equal(rdf_noex, rdf_ex)
 
+    def test_gsd_rdf_pair_order(self, gsdfile_bond):
+        rdf, norm = gsd_rdf(gsdfile_bond, "A", "B")
+        rdf_y = rdf.rdf*norm
+        rdf2, norm2 = gsd_rdf(gsdfile_bond, "B", "A")
+        rdf_y2 = rdf2.rdf*norm2
+
+        for i,j in zip(rdf_y, rdf_y2):
+            assert np.allclose(i,j,atol=1e-4)
+
     def test_get_quaternions(self):
         with pytest.raises(ValueError):
             get_quaternions(0)


### PR DESCRIPTION
 This addresses #28 and fixes the RDF normalization errors that result when types A and B are different, and there are different amount of each type.

I'm leaving this as a WIP, as I don't think we are totally sure of the origin of the issue and might want to discuss it more, but this does fix the normalization issues. In other words, the RDFs returned are the same regardless of what order types A and B are passed into `gsd_rdf` when there are different amounts of A/B types in the system..