### PR TITLE
Bond length and angle distributions

### DIFF
--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -20,6 +20,7 @@ def angle_distribution(
     A_name, B_name, C_name : str
         Name(s) of particles that form the angle triplet 
         (found in gsd.hoomd.Snapshot.particles.types)
+        They must be given in the same order as they form the angle
     start : int
         Starting frame index for accumulating bond lengths.
         Negative numbers index from the end. (default 0)
@@ -28,14 +29,13 @@ def angle_distribution(
 
     Returns
     -------
-    1D nump.array 
-        Array of angles in degrees
+    1-D nump.array 
+        Array of bond angles in degrees
 
     """
     angles = []
     trajectory = gsd.hoomd.open(gsd_file, mode="rb")
     angle_name = "-".join([A_name, B_name, C_name])
-    print(angle_name)
     for snap in trajectory[start: stop]:
         if angle_name not in snap.angles.types:
             raise ValueError(
@@ -104,7 +104,7 @@ def bond_distribution(
                         np.round(np.linalg.norm(pos2_unwrap - pos1_unwrap), 3)
                     )
     trajectory.close()
-    return bonds
+    return np.array(bonds) 
 
 
 def get_quaternions(n_views = 20):

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -37,6 +37,8 @@ def angle_distribution(
     trajectory = gsd.hoomd.open(gsd_file, mode="rb")
     name = "-".join([A_name, B_name, C_name])
     name_rev = "-".join([C_name, B_name, A_name])
+
+    angles = []
     for snap in trajectory[start: stop]:
         if name not in snap.angles.types and name_rev not in snap.angles.types:
             raise ValueError(
@@ -88,10 +90,11 @@ def bond_distribution(
         Array of bond lengths
 
     """
-    bonds = []
     trajectory = gsd.hoomd.open(gsd_file, mode="rb")
     name = "-".join([A_name, B_name])
-    name_rev = name[::-1]
+    name_rev = "-".join([B_name, A_name])
+
+    bonds = []
     for snap in trajectory[start:stop]:
         if name not in snap.bonds.types and name_rev not in snap.bonds.types:
             raise ValueError(f"Bond types {name} and {name_rev} not found "

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -29,23 +29,25 @@ def angle_distribution(
 
     Returns
     -------
-    1-D nump.array 
+    1-D numpy.array 
         Array of bond angles in degrees
 
     """
     angles = []
     trajectory = gsd.hoomd.open(gsd_file, mode="rb")
-    angle_name = "-".join([A_name, B_name, C_name])
+    name = "-".join([A_name, B_name, C_name])
+    name_rev = "-".join([C_name, B_name, A_name])
     for snap in trajectory[start: stop]:
-        if angle_name not in snap.angles.types:
+        if name not in snap.angles.types and name_rev not in snap.angles.types:
             raise ValueError(
-                    f"Angle {angle_name} not found in snap.angles.types. "
+                    f"Angles {name} or {name_rev} not found in "
+                    " snap.angles.types. "
                     "A_name, B_name, C_name must match the order "
                     "as they appear in snap.angles.types."
                 )
         for idx, angle_id in enumerate(snap.angles.typeid):
-            _angle_name = snap.angles.types[angle_id]
-            if _angle_name == angle_name:
+            angle_name = snap.angles.types[angle_id]
+            if angle_name == name or angle_name == name_rev:
                 pos1 = snap.particles.position[snap.angles.group[idx][0]]
                 img1 = snap.particles.image[snap.angles.group[idx][0]]
                 pos2 = snap.particles.position[snap.angles.group[idx][1]]
@@ -88,13 +90,16 @@ def bond_distribution(
     """
     bonds = []
     trajectory = gsd.hoomd.open(gsd_file, mode="rb")
+    name = "-".join([A_name, B_name])
+    name_rev = name[::-1]
     for snap in trajectory[start:stop]:
+        if name not in snap.bonds.types and name_rev not in snap.bonds.types:
+            raise ValueError(f"Bond types {name} and {name_rev} not found "
+                    "snap.bonds.types."
+                )
         for idx, bond in enumerate(snap.bonds.typeid):
             bond_name = snap.bonds.types[bond]
-            if bond_name in [
-                    "-".join([A_name, B_name]),
-                    "-".join([B_name, A_name])
-                ]:
+            if bond_name in [name, name_rev]:
                 pos1 = snap.particles.position[snap.bonds.group[idx][0]]
                 img1 = snap.particles.image[snap.bonds.group[idx][0]]
                 pos2 = snap.particles.position[snap.bonds.group[idx][1]]

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -55,7 +55,7 @@ def angle_distribution(
                 pos1_unwrap = pos1 + (img1 * snap.configuration.box[:3])
                 pos2_unwrap = pos2 + (img2 * snap.configuration.box[:3])
                 pos3_unwrap = pos3 + (img3 * snap.configuration.box[:3])
-                u = pos1_unwrap - pos2_unwrap
+                u = pos2_unwrap - pos1_unwrap
                 v = pos3_unwrap - pos2_unwrap
                 angles.append(np.round(angle_between_vectors(u, v, False), 3))
     trajectory.close()

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -28,12 +28,13 @@ def angle_distribution(
 
     Returns
     -------
-    List of angles (in degrees)
+    1D nump.array 
+        Array of angles in degrees
 
     """
     angles = []
     trajectory = gsd.hoomd.open(gsd_file, mode="rb")
-    for snap in trajectory[start, stop]:
+    for snap in trajectory[start: stop]:
         for idx, angle_id in enumerate(snap.angles.typeid):
             angle_name = snap.angles.types[angle_id]
             if angle_name == "-".join([A_name, B_name, C_name]):
@@ -49,7 +50,8 @@ def angle_distribution(
                 u = pos1_unwrap - pos2_unwrap
                 v = pos3_unwrap - pos2_unwrap
                 angles.append(np.round(angle_between_vectors(u, v, False), 3))
-    return angles
+    trajectory.close()
+    return np.array(angles)
 
 
 def bond_distribution(

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -82,7 +82,8 @@ def bond_distribution(
 
     Returns
     -------
-    List of bond lengths
+    1-D numpy array
+        Array of bond lengths
 
     """
     bonds = []

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -97,7 +97,7 @@ def bond_distribution(
     bonds = []
     for snap in trajectory[start:stop]:
         if name not in snap.bonds.types and name_rev not in snap.bonds.types:
-            raise ValueError(f"Bond types {name} and {name_rev} not found "
+            raise ValueError(f"Bond types {name} or {name_rev} not found "
                     "snap.bonds.types."
                 )
         for idx, bond in enumerate(snap.bonds.typeid):

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -34,10 +34,18 @@ def angle_distribution(
     """
     angles = []
     trajectory = gsd.hoomd.open(gsd_file, mode="rb")
+    angle_name = "-".join([A_name, B_name, C_name])
+    print(angle_name)
     for snap in trajectory[start: stop]:
+        if angle_name not in snap.angles.types:
+            raise ValueError(
+                    f"Angle {angle_name} not found in snap.angles.types. "
+                    "A_name, B_name, C_name must match the order "
+                    "as they appear in snap.angles.types."
+                )
         for idx, angle_id in enumerate(snap.angles.typeid):
-            angle_name = snap.angles.types[angle_id]
-            if angle_name == "-".join([A_name, B_name, C_name]):
+            _angle_name = snap.angles.types[angle_id]
+            if _angle_name == angle_name:
                 pos1 = snap.particles.position[snap.angles.group[idx][0]]
                 img1 = snap.particles.image[snap.angles.group[idx][0]]
                 pos2 = snap.particles.position[snap.angles.group[idx][1]]
@@ -79,10 +87,9 @@ def bond_distribution(
     """
     bonds = []
     trajectory = gsd.hoomd.open(gsd_file, mode="rb")
-    for snap in trajectory[start, stop]:
+    for snap in trajectory[start:stop]:
         for idx, bond in enumerate(snap.bonds.typeid):
             bond_name = snap.bonds.types[bond]
-            print(bond_name)
             if bond_name in [
                     "-".join([A_name, B_name]),
                     "-".join([B_name, A_name])

--- a/cmeutils/tests/test_structure.py
+++ b/cmeutils/tests/test_structure.py
@@ -27,6 +27,18 @@ class TestStructure(BaseTest):
         with pytest.raises(ValueError):
             angles = angle_distribution(p3ht_gsd, "cc", "xx", "cc", start=0, stop=1)
 
+    def test_bond_distribution(self, p3ht_gsd):
+        bonds = bond_distribution(p3ht_gsd, "cc", "ss", start=0, stop=1)
+        for bond in bonds:
+            assert 0.45 < bond < 0.52
+
+    def test_bond_distribution_order(self, p3ht_gsd):
+        bonds = bond_distribution(p3ht_gsd, "cc", "ss", start=0, stop=1)
+        bonds2 = bond_distribution(p3ht_gsd, "ss", "cc", start=0, stop=1)
+        assert bonds.shape == bonds2.shape
+        for i, j in zip(bonds, bonds2):
+            assert i == j
+
     def test_gsd_rdf(self, gsdfile_bond):
         rdf_ex, norm = gsd_rdf(gsdfile_bond, "A", "B")
         rdf_noex, norm2 = gsd_rdf(gsdfile_bond, "A", "B", exclude_bonded=False)

--- a/cmeutils/tests/test_structure.py
+++ b/cmeutils/tests/test_structure.py
@@ -28,6 +28,7 @@ class TestStructure(BaseTest):
         angles2 = angle_distribution(p3ht_gsd, "cd", "cc", "ss", start=0, stop=1)
         assert angles.shape[0] > 0
         assert angles.shape == angles2.shape
+        assert np.array_equal(angles, angles2)
 
     def test_angle_not_found(self, p3ht_gsd):
         with pytest.raises(ValueError):
@@ -42,8 +43,7 @@ class TestStructure(BaseTest):
         bonds = bond_distribution(p3ht_gsd, "cc", "ss", start=0, stop=1)
         bonds2 = bond_distribution(p3ht_gsd, "ss", "cc", start=0, stop=1)
         assert bonds.shape == bonds2.shape
-        for i, j in zip(bonds, bonds2):
-            assert i == j
+        assert np.array_equal(bonds, bonds2)
 
     def test_bond_not_found(self, p3ht_gsd):
         with pytest.raises(ValueError):

--- a/cmeutils/tests/test_structure.py
+++ b/cmeutils/tests/test_structure.py
@@ -23,6 +23,12 @@ class TestStructure(BaseTest):
         for ang in angles:
             assert 80 < ang < 100
 
+    def test_angle_distribution_order(self, p3ht_gsd):
+        angles = angle_distribution(p3ht_gsd, "ss", "cc", "cd", start=0, stop=1)
+        angles2 = angle_distribution(p3ht_gsd, "cd", "cc", "ss", start=0, stop=1)
+        assert angles.shape[0] > 0
+        assert angles.shape == angles2.shape
+
     def test_angle_not_found(self, p3ht_gsd):
         with pytest.raises(ValueError):
             angles = angle_distribution(p3ht_gsd, "cc", "xx", "cc", start=0, stop=1)
@@ -38,6 +44,10 @@ class TestStructure(BaseTest):
         assert bonds.shape == bonds2.shape
         for i, j in zip(bonds, bonds2):
             assert i == j
+
+    def test_bond_not_found(self, p3ht_gsd):
+        with pytest.raises(ValueError):
+            bonds = bond_distribution(p3ht_gsd, "xx", "ss", start=0, stop=1)
 
     def test_gsd_rdf(self, gsdfile_bond):
         rdf_ex, norm = gsd_rdf(gsdfile_bond, "A", "B")

--- a/cmeutils/tests/test_structure.py
+++ b/cmeutils/tests/test_structure.py
@@ -7,9 +7,22 @@ import freud
 
 from cmeutils.tests.base_test import BaseTest
 
-from cmeutils.structure import gsd_rdf, get_quaternions, order_parameter, all_atom_rdf, get_centers
+from cmeutils.structure import (
+        angle_distribution,
+        bond_distribution,
+        gsd_rdf,
+        get_quaternions, 
+        order_parameter,
+        all_atom_rdf,
+        get_centers
+    )
 
 class TestStructure(BaseTest):
+    def test_angle_distribution(self, p3ht_gsd):
+        angles = angle_distribution(p3ht_gsd, "cc", "ss", "cc")
+        for ang in angles:
+            assert 80 < ang < 100
+
     def test_gsd_rdf(self, gsdfile_bond):
         rdf_ex, norm = gsd_rdf(gsdfile_bond, "A", "B")
         rdf_noex, norm2 = gsd_rdf(gsdfile_bond, "A", "B", exclude_bonded=False)

--- a/cmeutils/tests/test_structure.py
+++ b/cmeutils/tests/test_structure.py
@@ -19,9 +19,13 @@ from cmeutils.structure import (
 
 class TestStructure(BaseTest):
     def test_angle_distribution(self, p3ht_gsd):
-        angles = angle_distribution(p3ht_gsd, "cc", "ss", "cc")
+        angles = angle_distribution(p3ht_gsd, "cc", "ss", "cc", start=0, stop=1)
         for ang in angles:
             assert 80 < ang < 100
+
+    def test_angle_not_found(self, p3ht_gsd):
+        with pytest.raises(ValueError):
+            angles = angle_distribution(p3ht_gsd, "cc", "xx", "cc", start=0, stop=1)
 
     def test_gsd_rdf(self, gsdfile_bond):
         rdf_ex, norm = gsd_rdf(gsdfile_bond, "A", "B")


### PR DESCRIPTION
This PR creates 2 functions. One that returns the bond lengths for a given bond pair, and one that returns bond angles for a given angle triplet.  It allows the user to accumulate lengths and angles over a range of snapshots for better sampling.

A quick note about handling PBCs: I chose to use the periodic images stored in the gsd file to unwrap positions before finding the bond vectors. I think the other option would be to check if a vector is larger than half the box and correct it using the box length, but I'm not sure how to do that if we don't have a cubic volume. IMO, unwrapping the relevant positions first seems like the best option.

