### PR TITLE
Add get_histogram utility, option to return histogram of bond lengths and angles

### DIFF
--- a/cmeutils/plotting.py
+++ b/cmeutils/plotting.py
@@ -27,10 +27,7 @@ def get_histogram(data, normalize=False, bins="auto"):
     """
     bin_heights, bin_borders = np.histogram(data, bins=bins)
     if normalize is True:
-        s = sum(bin_heights)
-        bin_heights = np.array(
-                [float(i)/s for i in bin_heights]
-        )
+        bin_heights = bin_heights/sum(bin_heights)
     bin_widths = np.diff(bin_borders)
     bin_centers = bin_borders[:-1] + bin_widths / 2
     return bin_centers, bin_heights

--- a/cmeutils/plotting.py
+++ b/cmeutils/plotting.py
@@ -11,6 +11,8 @@ def get_histogram(data, normalize=False, bins="auto"):
         Array of data used to generate the histogram
     normalize : boolean, default=False
         If set to true, normalizes the histogram bin heights
+        by the sum of data so that the distribution adds
+        up to 1
     bins : float, int, or str, default="auto"
         Method used by numpy to determine bin borders.
         Check the numpy.histogram docs for more details.

--- a/cmeutils/plotting.py
+++ b/cmeutils/plotting.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+
+def get_histogram(data, normalize=False, bins="auto"):
+    """Bins a 1-D array of data into a histogram using
+    the numpy.histogram method.
+
+    Parameters
+    ----------
+    data : 1-D numpy.array, required
+        Array of data used to generate the histogram
+    normalize : boolean, default=False
+        If set to true, normalizes the histogram bin heights
+    bins : float, int, or str, default="auto"
+        Method used by numpy to determine bin borders.
+        Check the numpy.histogram docs for more details.
+
+    Returns
+    -------
+    bin_cetners : 1-D numpy.array
+        Array of the bin center values
+    bin_heights : 1-D numpy.array
+        Array of the bin height values
+
+    """
+    bin_heights, bin_borders = np.histogram(data, bins=bins)
+    if normalize is True:
+        bin_heights = [float(i)/sum(bin_heights) for i in bin_heights]
+    bin_widths = np.diff(bin_borders)
+    bin_centers = bin_borders[:-1] + bin_widths / 2
+    return bin_centers, bin_heights

--- a/cmeutils/plotting.py
+++ b/cmeutils/plotting.py
@@ -25,8 +25,9 @@ def get_histogram(data, normalize=False, bins="auto"):
     """
     bin_heights, bin_borders = np.histogram(data, bins=bins)
     if normalize is True:
+        s = sum(bin_heights)
         bin_heights = np.array(
-                [float(i)/sum(bin_heights) for i in bin_heights]
+                [float(i)/s for i in bin_heights]
         )
     bin_widths = np.diff(bin_borders)
     bin_centers = bin_borders[:-1] + bin_widths / 2

--- a/cmeutils/plotting.py
+++ b/cmeutils/plotting.py
@@ -25,7 +25,9 @@ def get_histogram(data, normalize=False, bins="auto"):
     """
     bin_heights, bin_borders = np.histogram(data, bins=bins)
     if normalize is True:
-        bin_heights = [float(i)/sum(bin_heights) for i in bin_heights]
+        bin_heights = np.array(
+                [float(i)/sum(bin_heights) for i in bin_heights]
+        )
     bin_widths = np.diff(bin_borders)
     bin_centers = bin_borders[:-1] + bin_widths / 2
     return bin_centers, bin_heights

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -6,10 +6,11 @@ from rowan import vector_vector_rotation
 
 from cmeutils import gsd_utils
 from cmeutils.geometry import get_plane_normal, angle_between_vectors
+from cmeutils.plotting import get_histogram
 
 
 def angle_distribution(
-        gsd_file, A_name, B_name, C_name, start=0, stop=-1
+        gsd_file, A_name, B_name, C_name, start=0, stop=-1, histogram=False
 ):
     """Returns the bond angle distribution for a given triplet of particles 
     
@@ -26,11 +27,18 @@ def angle_distribution(
         Negative numbers index from the end. (default 0)
     stop : int
         Final frame index for accumulating bond lengths. (default -1)
+    histogram : bool, default=False
+        If set to True, places the resulting angles into a histogram
+        and retrums the histogram's bin centers and heights as 
+        opposed to the actual calcualted angles.
 
     Returns
     -------
     1-D numpy.array 
-        Array of bond angles in degrees
+        If histogram is False, Array of actual bond angles in degrees
+    
+    tuple of (bin_centers, bin_heights)
+        If histogram is True, returns a tuple of two arrays.
 
     """
     angles = []
@@ -63,11 +71,16 @@ def angle_distribution(
                 v = pos3_unwrap - pos2_unwrap
                 angles.append(np.round(angle_between_vectors(u, v, False), 3))
     trajectory.close()
-    return np.array(angles)
+
+    if histogram:
+        bin_centers, bin_heights = get_histogram(angles)
+        return bin_centers, bin_heights
+    else:
+        return np.array(angles)
 
 
 def bond_distribution(
-    gsd_file, A_name, B_name, start=0, stop=-1
+    gsd_file, A_name, B_name, start=0, stop=-1, histogram=False
 ):
     """Returns the bond length distribution for a given bond pair 
     
@@ -83,11 +96,18 @@ def bond_distribution(
         Negative numbers index from the end. (default 0)
     stop : int
         Final frame index for accumulating bond lengths. (default -1)
+    histogram : bool, default=False
+        If set to True, places the resulting bonds into a histogram
+        and retrums the histogram's bin centers and heights as 
+        opposed to the actual calcualted bonds.
 
     Returns
     -------
-    1-D numpy array
-        Array of bond lengths
+    1-D numpy.array 
+        If histogram is False, Array of actual bond lengths
+    
+    tuple of (bin_centers, bin_heights)
+        If histogram is True, returns a tuple of two arrays.
 
     """
     trajectory = gsd.hoomd.open(gsd_file, mode="rb")
@@ -113,7 +133,12 @@ def bond_distribution(
                         np.round(np.linalg.norm(pos2_unwrap - pos1_unwrap), 3)
                     )
     trajectory.close()
-    return np.array(bonds) 
+
+    if histogram:
+        bin_centers, bin_heights = get_histogram(bonds)
+        return bin_centers, bin_heights
+    else:
+        return np.array(bonds)
 
 
 def get_quaternions(n_views = 20):

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -10,7 +10,14 @@ from cmeutils.plotting import get_histogram
 
 
 def angle_distribution(
-        gsd_file, A_name, B_name, C_name, start=0, stop=-1, histogram=False
+        gsd_file,
+        A_name,
+        B_name,
+        C_name,
+        start=0,
+        stop=-1,
+        histogram=False,
+        bins="auto"
 ):
     """Returns the bond angle distribution for a given triplet of particles 
     
@@ -31,6 +38,11 @@ def angle_distribution(
         If set to True, places the resulting angles into a histogram
         and retrums the histogram's bin centers and heights as 
         opposed to the actual calcualted angles.
+    bins : float, int, or str,  default="auto"
+        The number of bins to use when finding the distribution
+        of bond angles. Using "auto" will set the number of
+        bins based on the ideal bin size for the data. 
+        See the numpy.histogram docs for more details.
 
     Returns
     -------
@@ -71,14 +83,14 @@ def angle_distribution(
     trajectory.close()
 
     if histogram:
-        bin_centers, bin_heights = get_histogram(np.array(angles))
+        bin_centers, bin_heights = get_histogram(np.array(angles), bins=bins)
         return np.stack((bin_centers, bin_heights)).T
     else:
         return np.array(angles)
 
 
 def bond_distribution(
-    gsd_file, A_name, B_name, start=0, stop=-1, histogram=False
+    gsd_file, A_name, B_name, start=0, stop=-1, histogram=False, bins=100
 ):
     """Returns the bond length distribution for a given bond pair 
     
@@ -98,6 +110,11 @@ def bond_distribution(
         If set to True, places the resulting bonds into a histogram
         and retrums the histogram's bin centers and heights as 
         opposed to the actual calcualted bonds.
+    bins : float, int, or str,  default="auto"
+        The number of bins to use when finding the distribution
+        of bond angles. Using "auto" will set the number of
+        bins based on the ideal bin size for the data. 
+        See the numpy.histogram docs for more details.
 
     Returns
     -------
@@ -131,7 +148,7 @@ def bond_distribution(
     trajectory.close()
 
     if histogram:
-        bin_centers, bin_heights = get_histogram(np.array(bonds))
+        bin_centers, bin_heights = get_histogram(np.array(bonds), bins=bins)
         return np.stack((bin_centers, bin_heights)).T
     else:
         return np.array(bonds)

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -34,11 +34,9 @@ def angle_distribution(
 
     Returns
     -------
-    1-D numpy.array 
+    1-D numpy.array  or 2-D numpy.array
         If histogram is False, Array of actual bond angles in degrees
-    
-    tuple of (bin_centers, bin_heights)
-        If histogram is True, returns a tuple of two arrays.
+        If histogram is True, returns a 2D array of bin centers and bin heights.
 
     """
     angles = []
@@ -74,7 +72,7 @@ def angle_distribution(
 
     if histogram:
         bin_centers, bin_heights = get_histogram(np.array(angles))
-        return bin_centers, bin_heights
+        return np.array([bin_centers, bin_heights])
     else:
         return np.array(angles)
 
@@ -103,11 +101,9 @@ def bond_distribution(
 
     Returns
     -------
-    1-D numpy.array 
-        If histogram is False, Array of actual bond lengths
-    
-    tuple of (bin_centers, bin_heights)
-        If histogram is True, returns a tuple of two arrays.
+    1-D numpy.array  or 2-D numpy.array
+        If histogram is False, Array of actual bond angles in degrees
+        If histogram is True, returns a 2D array of bin centers and bin heights.
 
     """
     trajectory = gsd.hoomd.open(gsd_file, mode="rb")
@@ -136,7 +132,7 @@ def bond_distribution(
 
     if histogram:
         bin_centers, bin_heights = get_histogram(np.array(bonds))
-        return bin_centers, bin_heights
+        return np.array([bin_centers, bin_heights])
     else:
         return np.array(bonds)
 

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -17,6 +17,7 @@ def angle_distribution(
         start=0,
         stop=-1,
         histogram=False,
+        normalize=False,
         bins="auto"
 ):
     """Returns the bond angle distribution for a given triplet of particles 
@@ -38,6 +39,9 @@ def angle_distribution(
         If set to True, places the resulting angles into a histogram
         and retrums the histogram's bin centers and heights as 
         opposed to the actual calcualted angles.
+    normalize : bool, default=False
+        If set to True, normalizes the angle distribution by the
+        sum of the bin heights, so that the distribution adds up to 1. 
     bins : float, int, or str,  default="auto"
         The number of bins to use when finding the distribution
         of bond angles. Using "auto" will set the number of
@@ -90,7 +94,14 @@ def angle_distribution(
 
 
 def bond_distribution(
-    gsd_file, A_name, B_name, start=0, stop=-1, histogram=False, bins=100
+    gsd_file,
+    A_name,
+    B_name,
+    start=0,
+    stop=-1,
+    histogram=False,
+    normalize=True,
+    bins=100
 ):
     """Returns the bond length distribution for a given bond pair 
     
@@ -110,6 +121,9 @@ def bond_distribution(
         If set to True, places the resulting bonds into a histogram
         and retrums the histogram's bin centers and heights as 
         opposed to the actual calcualted bonds.
+    normalize : bool, default=False
+        If set to True, normalizes the angle distribution by the
+        sum of the bin heights, so that the distribution adds up to 1. 
     bins : float, int, or str,  default="auto"
         The number of bins to use when finding the distribution
         of bond angles. Using "auto" will set the number of

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -73,7 +73,7 @@ def angle_distribution(
     trajectory.close()
 
     if histogram:
-        bin_centers, bin_heights = get_histogram(angles)
+        bin_centers, bin_heights = get_histogram(np.array(angles))
         return bin_centers, bin_heights
     else:
         return np.array(angles)
@@ -135,7 +135,7 @@ def bond_distribution(
     trajectory.close()
 
     if histogram:
-        bin_centers, bin_heights = get_histogram(bonds)
+        bin_centers, bin_heights = get_histogram(np.array(bonds))
         return bin_centers, bin_heights
     else:
         return np.array(bonds)

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -72,7 +72,7 @@ def angle_distribution(
 
     if histogram:
         bin_centers, bin_heights = get_histogram(np.array(angles))
-        return np.array([bin_centers, bin_heights])
+        return np.stack((bin_centers, bin_heights)).T
     else:
         return np.array(angles)
 
@@ -132,7 +132,7 @@ def bond_distribution(
 
     if histogram:
         bin_centers, bin_heights = get_histogram(np.array(bonds))
-        return np.array([bin_centers, bin_heights])
+        return np.stack((bin_centers, bin_heights)).T
     else:
         return np.array(bonds)
 

--- a/cmeutils/tests/test_plotting.py
+++ b/cmeutils/tests/test_plotting.py
@@ -14,6 +14,5 @@ class TestPlotting(BaseTest):
     def test_histogram_normalize(self):
         sample = np.random.randn(100)*-1
         bin_c, bin_h = get_histogram(sample, normalize=True)
-        for n in bin_h:
-            assert n <= 1
+        assert all(bin_h <= 1)
 

--- a/cmeutils/tests/test_plotting.py
+++ b/cmeutils/tests/test_plotting.py
@@ -1,0 +1,19 @@
+import numpy as np
+import pytest
+
+from cmeutils.plotting import get_histogram
+from base_test import BaseTest
+
+
+class TestPlotting(BaseTest):
+    def test_histogram_bins(self):
+        sample = np.random.randn(100)
+        bin_c, bin_h = get_histogram(sample, bins=20)
+        assert len(bin_c) == len(bin_h) == 20
+
+    def test_histogram_normalize(self):
+        sample = np.random.randn(100)*-1
+        bin_c, bin_h = get_histogram(sample, normalize=True)
+        for n in bin_h:
+            assert n <= 1
+

--- a/cmeutils/tests/test_structure.py
+++ b/cmeutils/tests/test_structure.py
@@ -61,10 +61,10 @@ class TestStructure(BaseTest):
 
     def test_angle_histogram(self, p3ht_gsd):
         angles_hist = angle_distribution(
-                p3ht_gsd, "cc", "ss", start=0, stop=1, histogram=True
+                p3ht_gsd, "cc", "ss", "cc", start=0, stop=1, histogram=True
         )
         angles_no_hist = angle_distribution(
-                p3ht_gsd, "cc", "ss", start=0, stop=1, histogram=False
+                p3ht_gsd, "cc", "ss", "cc", start=0, stop=1, histogram=False
         )
         assert angles_hist.ndim == 2
         assert angles_no_hist.ndim == 1

--- a/cmeutils/tests/test_structure.py
+++ b/cmeutils/tests/test_structure.py
@@ -49,6 +49,26 @@ class TestStructure(BaseTest):
         with pytest.raises(ValueError):
             bonds = bond_distribution(p3ht_gsd, "xx", "ss", start=0, stop=1)
 
+    def test_bond_histogram(self, p3ht_gsd):
+        bonds_hist = bond_distribution(
+                p3ht_gsd, "cc", "ss", start=0, stop=1, histogram=True
+        )
+        bonds_no_hist = bond_distribution(
+                p3ht_gsd, "cc", "ss", start=0, stop=1, histogram=False
+        )
+        assert bonds_hist.ndim == 2
+        assert bonds_no_hist.ndim == 1
+
+    def test_angle_histogram(self, p3ht_gsd):
+        angles_hist = angle_distribution(
+                p3ht_gsd, "cc", "ss", start=0, stop=1, histogram=True
+        )
+        angles_no_hist = angle_distribution(
+                p3ht_gsd, "cc", "ss", start=0, stop=1, histogram=False
+        )
+        assert angles_hist.ndim == 2
+        assert angles_no_hist.ndim == 1
+
     def test_gsd_rdf(self, gsdfile_bond):
         rdf_ex, norm = gsd_rdf(gsdfile_bond, "A", "B")
         rdf_noex, norm2 = gsd_rdf(gsdfile_bond, "A", "B", exclude_bonded=False)


### PR DESCRIPTION
Both of the `angle_distribution` and `bond_distribution` functions are a bit of a misnomer.  Currently, they only return an array of the calculated bond angles and lengths, rather than giving the actual distributions.

This PR adds an additional parameter to these functions that returns a distribution of these values. I decided to add a parameter rather than outright changing the behavior of the function in case there are still use cases where we want a list of the actual bond lengths and angles. However, I'm open to changing this if someone thinks there is a better approach.

I still need to add some unit tests.