### PR TITLE
remove hoomd 2 from environment file

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -40,6 +40,12 @@ jobs:
       shell: bash -l {0}
       run: python -m pytest -v -rs --cov=./ --cov-report=xml
 
+    - name: Test hoomd2 functions
+      shell: bash -l {0}
+      run: |
+        mamba install -c conda-forge hoomd=2
+        python -m pytest -v -rs -k test_xml_to_gsd --cov=./ --cov-report=xml --cov-append
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/cmeutils/gsd_utils.py
+++ b/cmeutils/gsd_utils.py
@@ -2,8 +2,6 @@ from tempfile import NamedTemporaryFile
 
 import freud
 import gsd.hoomd
-import hoomd
-import hoomd.deprecated
 import numpy as np
 
 
@@ -202,6 +200,14 @@ def xml_to_gsd(xmlfile, gsdfile):
     gsdfile : str
         Path to gsd file
     """
+    try:
+        import hoomd
+        import hoomd.deprecated
+    except ImportError:
+        raise ImportError(
+                "You must have hoomd version 2 installed to use xml_to_gsd()"
+        )
+
     hoomd.util.quiet_status()
     hoomd.context.initialize("")
     hoomd.deprecated.init.read_xml(xmlfile, restart=xmlfile)

--- a/cmeutils/tests/test_gsd.py
+++ b/cmeutils/tests/test_gsd.py
@@ -2,12 +2,23 @@ import pytest
 
 import gsd.hoomd
 import numpy as np
+import packaging.version
 
 from base_test import BaseTest
 from cmeutils.gsd_utils import (
     get_type_position, get_molecule_cluster, get_all_types, _validate_inputs,
     snap_delete_types, xml_to_gsd
 )
+
+try:
+    import hoomd
+    if "version" in dir(hoomd):
+        hoomd_version = packaging.version.parse(hoomd.version.version)
+    else:
+        hoomd_version = packaging.version.parse(hoomd.__version__)
+    has_hoomd = True
+except ImportError:
+    has_hoomd = False
 
 
 class TestGSD(BaseTest):
@@ -57,7 +68,10 @@ class TestGSD(BaseTest):
         new_snap = snap_delete_types(snap_bond, "A")
         assert "A" not in new_snap.particles.types
 
-    @pytest.mark.skip(reason="Requires that hoomd2 is installed.")
+    @pytest.mark.skipif(
+        not has_hoomd or hoomd_version.major != 2,
+        reason="HOOMD is not installed or is wrong version"
+    )
     def test_xml_to_gsd(self, tmp_path, p3ht_gsd, p3ht_xml):
         new_gsd = tmp_path / "new.gsd"
         xml_to_gsd(p3ht_xml, new_gsd)

--- a/cmeutils/tests/test_gsd.py
+++ b/cmeutils/tests/test_gsd.py
@@ -57,6 +57,7 @@ class TestGSD(BaseTest):
         new_snap = snap_delete_types(snap_bond, "A")
         assert "A" not in new_snap.particles.types
 
+    @pytest.mark.skip(reason="Requires that hoomd2 is installed.")
     def test_xml_to_gsd(self, tmp_path, p3ht_gsd, p3ht_xml):
         new_gsd = tmp_path / "new.gsd"
         xml_to_gsd(p3ht_xml, new_gsd)

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,6 @@ channels:
 dependencies:
   - freud
   - gsd
-  - hoomd<3
   - numpy
   - pip
   - python=3.7


### PR DESCRIPTION
Having hoomd2 as a dependency creates a problem when trying to use cmeutils in an environment that also has hoomd 3.  Since we only need hoomd for the `xml_to_gsd` function, I moved the hoomd imports inside of that function and throw an error if the user needs to add hoomd 2 to their environment.