### PR TITLE
Fix normalizaiton of bond and angle distributions

### DIFF
--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -114,7 +114,10 @@ def angle_distribution(
                     "include all bond angles."
             )
         bin_centers, bin_heights = get_histogram(
-                np.array(angles), bins=bins, x_range=(theta_min, theta_max)
+                data=np.array(angles),
+                normalize=normalize,
+                bins=bins,
+                x_range=(theta_min, theta_max)
         )
         return np.stack((bin_centers, bin_heights)).T
     else:
@@ -202,7 +205,10 @@ def bond_distribution(
                     "this range to include all bond lengths."
             )
         bin_centers, bin_heights = get_histogram(
-                np.array(bonds), bins=bins, x_range=(l_min, l_max)
+                data = np.array(bonds),
+                normalize=normalize,
+                bins=bins,
+                x_range=(l_min, l_max)
         )
         return np.stack((bin_centers, bin_heights)).T
     else:

--- a/cmeutils/tests/test_structure.py
+++ b/cmeutils/tests/test_structure.py
@@ -105,7 +105,7 @@ class TestStructure(BaseTest):
                 histogram=True,
                 normalize=True
         )
-        assert np.allclose(np.sum(bonds_hist[:,1]), 1, 1e3)
+        assert np.allclose(np.sum(bonds_hist[:,1]), 1, 1e-3)
 
     def test_bond_range_outside(self, p3ht_gsd):
         with pytest.warns(UserWarning):
@@ -141,7 +141,7 @@ class TestStructure(BaseTest):
                 histogram=True,
                 normalize=True,
         )
-        assert np.allclose(np.sum(angles_hist[:,1]), 1, 1e3)
+        assert np.allclose(np.sum(angles_hist[:,1]), 1, 1e-3)
     
     def test_angle_range_outside(self, p3ht_gsd):
         with pytest.warns(UserWarning):

--- a/cmeutils/tests/test_structure.py
+++ b/cmeutils/tests/test_structure.py
@@ -95,6 +95,18 @@ class TestStructure(BaseTest):
         assert bonds_hist.ndim == 2
         assert bonds_no_hist.ndim == 1
 
+    def test_bond_dist_normalize(self, p3ht_gsd):
+        bonds_hist = bond_distribution(
+                p3ht_gsd,
+                "cc",
+                "ss",
+                start=0,
+                stop=1,
+                histogram=True,
+                normalize=True
+        )
+        assert np.allclose(np.sum(bonds_hist[:,1]), 1, 1e3)
+
     def test_bond_range_outside(self, p3ht_gsd):
         with pytest.warns(UserWarning):
             bonds_hist = bond_distribution(
@@ -117,6 +129,19 @@ class TestStructure(BaseTest):
         )
         assert angles_hist.ndim == 2
         assert angles_no_hist.ndim == 1
+
+    def test_angle_dist_normalize(self, p3ht_gsd):
+        angles_hist = angle_distribution(
+                p3ht_gsd,
+                "cc",
+                "ss",
+                "cc",
+                start=0,
+                stop=1,
+                histogram=True,
+                normalize=True,
+        )
+        assert np.allclose(np.sum(angles_hist[:,1]), 1, 1e3)
     
     def test_angle_range_outside(self, p3ht_gsd):
         with pytest.warns(UserWarning):


### PR DESCRIPTION
It looks like the normalization parameter in both bond and angle distribution functions wasn't doing anything. The actual normalization is performed in `plotting.get_histogram`, which both of these functions use, but the normalization parameter was never passed along.  This PR fixes that, and adds 2 unit tests that call the bond and angle distribution functions (the normalization was already tested directly by calling `get_histogram`)