### PR TITLE
Update to pymbar Version 4

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -44,7 +44,7 @@ jobs:
       shell: bash -l {0}
       run: |
         mamba remove hoomd python -y
-        mamba install -c conda-forge python=3.9, "hoomd<3=*cpu*"
+        mamba install -c conda-forge python=3.9 "hoomd<3=*cpu*"
         python -m pytest -v -rs -k test_xml_to_gsd --cov=./ --cov-report=xml --cov-append
 
     - name: Upload coverage to Codecov

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Test hoomd2 functions
       shell: bash -l {0}
       run: |
-        mamba remove python
+        mamba remove hoomd python -y
         mamba install -c conda-forge python=3.9, "hoomd<3=*cpu*"
         python -m pytest -v -rs -k test_xml_to_gsd --cov=./ --cov-report=xml --cov-append
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -40,13 +40,6 @@ jobs:
       shell: bash -l {0}
       run: python -m pytest -v -rs --cov=./ --cov-report=xml
 
-    - name: Test hoomd2 functions
-      shell: bash -l {0}
-      run: |
-        mamba remove hoomd python -y
-        mamba install -c conda-forge python=3.9 pytest "hoomd<3=*cpu*"
-        python -m pytest -v -rs -k test_xml_to_gsd --cov=./ --cov-report=xml --cov-append
-
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -44,7 +44,7 @@ jobs:
       shell: bash -l {0}
       run: |
         mamba remove hoomd python -y
-        mamba install -c conda-forge python=3.9 "hoomd<3=*cpu*"
+        mamba install -c conda-forge python=3.9 pytest "hoomd<3=*cpu*"
         python -m pytest -v -rs -k test_xml_to_gsd --cov=./ --cov-report=xml --cov-append
 
     - name: Upload coverage to Codecov

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -43,7 +43,8 @@ jobs:
     - name: Test hoomd2 functions
       shell: bash -l {0}
       run: |
-        mamba install -c conda-forge hoomd=2
+        mamba remove python
+        mamba install -c conda-forge python=3.9, "hoomd<3=*cpu*"
         python -m pytest -v -rs -k test_xml_to_gsd --cov=./ --cov-report=xml --cov-append
 
     - name: Upload coverage to Codecov

--- a/cmeutils/gsd_utils.py
+++ b/cmeutils/gsd_utils.py
@@ -2,6 +2,7 @@ from tempfile import NamedTemporaryFile
 
 import freud
 import gsd.hoomd
+import hoomd
 import numpy as np
 
 from cmeutils.geometry import moit

--- a/cmeutils/gsd_utils.py
+++ b/cmeutils/gsd_utils.py
@@ -3,7 +3,6 @@ from tempfile import NamedTemporaryFile
 import freud
 import gsd.hoomd
 import numpy as np
-import hoomd
 
 from cmeutils.geometry import moit
 

--- a/cmeutils/sampling.py
+++ b/cmeutils/sampling.py
@@ -28,12 +28,12 @@ def equil_sample(
     """
     is_equil, prod_start, ineff, Neff = is_equilibrated(
             data, threshold_fraction, threshold_neff
-            )
+    )
 
     if is_equil:
-        uncorr_indices = timeseries.subsampleCorrelatedData(
+        uncorr_indices = timeseries.subsample_correlated_data(
                 data[prod_start:], g=ineff, conservative=conservative
-            )
+        )
         uncorr_sample = data[prod_start:][uncorr_indices]
         return(uncorr_sample, uncorr_indices, prod_start, Neff)
 
@@ -71,7 +71,7 @@ def is_equilibrated(data, threshold_fraction=0.50, threshold_neff=50, nskip=1):
         'equilibrated'.
     nskip : int, optional, default=1
         Since the statistical inefficiency is computed for every time origin
-        in a call to timeseries.detectEquilibration, for larger datasets
+        in a call to timeseries.detect_equilibration, for larger datasets
         (> few hundred), increasing nskip might speed this up, while
         discarding more data.
 
@@ -94,7 +94,7 @@ def is_equilibrated(data, threshold_fraction=0.50, threshold_neff=50, nskip=1):
             f"Passed 'threshold_neff' value: {threshold_neff}, expected value "
             "1 or greater."
         )
-    [t0, g, Neff] = timeseries.detectEquilibration(data, nskip=nskip)
+    [t0, g, Neff] = timeseries.detect_equilibration(data, nskip=nskip)
     frac_equilibrated = 1.0 - (t0 / np.shape(data)[0])
 
     if (frac_equilibrated >= threshold_fraction) and (Neff >= threshold_neff):

--- a/cmeutils/tests/test_gsd.py
+++ b/cmeutils/tests/test_gsd.py
@@ -102,10 +102,7 @@ class TestGSD(BaseTest):
         new_snap = snap_delete_types(snap_bond, "A")
         assert "A" not in new_snap.particles.types
 
-    @pytest.mark.skipif(
-        not has_hoomd or hoomd_version.major != 2,
-        reason="HOOMD is not installed or is wrong version"
-    )
+    @pytest.mark.skip(reason="HOOMD2 required for testing")
     def test_xml_to_gsd(self, tmp_path, p3ht_gsd, p3ht_xml):
         new_gsd = tmp_path / "new.gsd"
         xml_to_gsd(p3ht_xml, new_gsd)

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - pip
   - python
   - matplotlib
-  - pymbar < 4.0
+  - pymbar >= 4.0
   - pytest
   - pytest-cov
   - rowan

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - freud
   - gsd
+  - hoomd>3.0=*cpu*
   - mbuild
   - numpy
   - pip

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,6 @@ channels:
 dependencies:
   - freud
   - gsd
-  - hoomd
   - mbuild
   - numpy
   - pip


### PR DESCRIPTION
There were some breaking changes from pymbar 3 to 4, but for the purposes of what we use in cmeutils, it only requires changing some function names.  This PR should fix those, and changes the version to >= in the environment file.