### PR TITLE
Add 2D and 3D grid positions

### DIFF
--- a/cmeutils/dynamics.py
+++ b/cmeutils/dynamics.py
@@ -6,13 +6,14 @@ from warnings import warn
 
 from cmeutils import gsd_utils
 
+
 def msd_from_gsd(
         gsdfile,
         atom_types="all",
         start=0,
         stop=-1,
         msd_mode="window"
-        ):
+):
     """Calculate the mean-square displacement (MSD) of the particles in a
     trajectory using Freud.
 
@@ -36,8 +37,8 @@ def msd_from_gsd(
         init_box = trajectory[start].configuration.box
         final_box = trajectory[stop].configuration.box
         assert all(
-                [i == j for i,j in zip(init_box, final_box)]
-                ), f"The box is not consistent over the range {start}:{stop}"
+            [i == j for i, j in zip(init_box, final_box)]
+        ), f"The box is not consistent over the range {start}:{stop}"
 
         positions = []
         images = []
@@ -46,10 +47,10 @@ def msd_from_gsd(
                 atom_pos = frame.particles.position[:]
                 atom_img = frame.particles.image[:]
             else:
-                atom_pos, atom_img  = gsd_utils.get_type_position(
-                            atom_types,
-                            snap=frame,
-                            images=True
+                atom_pos, atom_img = gsd_utils.get_type_position(
+                    atom_types,
+                    snap=frame,
+                    images=True
                 )
             positions.append(atom_pos)
             images.append(atom_img)
@@ -58,8 +59,7 @@ def msd_from_gsd(
                 f"All of the images over the range {start}-{stop} "
                 "are [0,0,0]. You may want to ensure this gsd file "
                 "had the particle images written to it."
-                )
+            )
         msd = freud.msd.MSD(box=init_box, mode=msd_mode)
         msd.compute(np.array(positions), np.array(images), reset=False)
     return msd
- 

--- a/cmeutils/geometry.py
+++ b/cmeutils/geometry.py
@@ -116,7 +116,8 @@ def dihedral_angle(pos1, pos2, pos3, pos4, degrees=False):
     a2 = np.cross(v2, v3)
     a2 = a2 / (a2 * a2).sum(-1) ** 0.5
     porm = np.sign((a1 * v3).sum(-1))
-    phi = np.arccos((a1 * a2).sum(-1) / ((a1 ** 2).sum(-1) * (a2 ** 2).sum(-1)) ** 0.5)
+    phi = np.arccos(
+        (a1 * a2).sum(-1) / ((a1 ** 2).sum(-1) * (a2 ** 2).sum(-1)) ** 0.5)
     if porm != 0:
         phi = phi * porm
     if degrees:
@@ -155,52 +156,69 @@ def moit(points, masses, center=np.zeros(3)):
     return np.array((I_xx, I_yy, I_zz))
 
 
-def radial_grid_positions(init_radius, final_radius, init_position=np.zeros(2), n_circles=10, circle_slice=1,
+def radial_grid_positions(init_radius, final_radius, init_position=np.zeros(2),
+                          n_circles=10, circle_slice=1,
                           circle_coverage=2 * np.pi):
     """
     Generate a 2D grid of positions in a radial pattern.
     Parameters
     ----------
-    init_radius: initial radius of the grid (first circle).
-    final_radius: final radius of the grid (last circle).
-    init_position: initial position of the grid (center of the first circle).
-    n_circles: number of circles in the grid.
-    circle_slice: number of points in each circle.
-    circle_coverage: coverage of each circle in radians (range: 0 to 2*pi).
-
+    init_radius: float
+        initial radius of the grid (first circle)
+    final_radius: float
+        final radius of the grid (last circle)
+    init_position: numpy.ndarray (2,), default np.array([0,0])
+        initial position of the grid (center of the first circle)
+    n_circles: int, default 10
+        number of circles in the grid
+    circle_slice: int, default 1
+        number of points in each circle
+    circle_coverage: float, default 2*pi
+        coverage of each circle in radians (range: 0 to 2*pi)
     Returns
     -------
-    grid_positions: numpy.ndarray, shape (n_circles * circle_slice, 2)
-        xy coordinates of the grid positions.
+    grid_positions: numpy.ndarray(n_circles * circle_slice, 2)
+        xy coordinates of the grid positions
     """
 
     grid_positions = []
     for radius in np.linspace(init_radius, final_radius, n_circles):
         for d_theta in np.linspace(0, circle_coverage, circle_slice):
-            grid_positions.append((init_position[0] + np.round(radius * np.cos(d_theta), decimals=3),
-                                   init_position[1] + np.round(radius * np.sin(d_theta), decimals=3)))
+            grid_positions.append((init_position[0] + np.round(
+                radius * np.cos(d_theta), decimals=3),
+                                   init_position[1] + np.round(
+                                       radius * np.sin(d_theta), decimals=3)))
 
     return np.asarray(grid_positions)
 
 
-def spherical_grid_positions(init_radius, final_radius, init_position=np.zeros(3), n_circles=10, circle_slice=1,
+def spherical_grid_positions(init_radius, final_radius,
+                             init_position=np.zeros(3), n_circles=10,
+                             circle_slice=1,
                              circle_coverage=2 * np.pi, z_coverage=np.pi):
     """
     Generate a 3D grid of positions in a spherical pattern.
     Parameters
     ----------
-    init_radius: initial radius of the grid (first circle).
-    final_radius: final radius of the grid (last circle).
-    init_position: initial position of the grid (center of the first circle).
-    n_circles: number of circles in the grid.
-    circle_slice: number of points in each circle.
-    circle_coverage: coverage of each circle in radians (range: 0 to 2*pi).
-    z_coverage: coverage of the z axis in radians (range: 0 to pi).
+    init_radius: float
+        initial radius of the grid (first circle)
+    final_radius: float
+        final radius of the grid (last circle)
+    init_position: numpy.ndarray (3,), default np.array([0,0,0])
+        initial position of the grid (center of the first circle)
+    n_circles: int, default 10
+        number of circles in the grid
+    circle_slice: int, default 1
+        number of points in each circle
+    circle_coverage: float, default 2*pi
+        coverage of each circle in radians (range: 0 to 2*pi)
+    z_coverage: float, default pi
+        coverage of the z axis in radians (range: 0 to pi)
 
     Returns
     -------
     grid_positions: numpy.ndarray
-        xyz coordinates of the grid positions.
+        xyz coordinates of the grid positions
     """
 
     z_slice = circle_slice * 2
@@ -208,11 +226,13 @@ def spherical_grid_positions(init_radius, final_radius, init_position=np.zeros(3
     for radius in np.linspace(init_radius, final_radius, n_circles):
         for d_theta in np.linspace(0, circle_coverage, circle_slice):
             for d_phi in np.linspace(0, z_coverage, z_slice):
-                x = init_position[0] + np.round(radius * np.cos(d_theta) * np.sin(d_phi), decimals=3)
-                y = init_position[1] + np.round(radius * np.sin(d_theta) * np.sin(d_phi), decimals=3)
-                z = init_position[2] + np.round(radius * np.cos(d_phi), decimals=3)
+                x = init_position[0] + np.round(
+                    radius * np.cos(d_theta) * np.sin(d_phi), decimals=3)
+                y = init_position[1] + np.round(
+                    radius * np.sin(d_theta) * np.sin(d_phi), decimals=3)
+                z = init_position[2] + np.round(radius * np.cos(d_phi),
+                                                decimals=3)
                 if not (x, y, z) in grid_positions:
                     grid_positions.append((x, y, z))
 
     return np.asarray(grid_positions)
-

--- a/cmeutils/geometry.py
+++ b/cmeutils/geometry.py
@@ -156,11 +156,17 @@ def moit(points, masses, center=np.zeros(3)):
     return np.array((I_xx, I_yy, I_zz))
 
 
-def radial_grid_positions(init_radius, final_radius, init_position=np.zeros(2),
-                          n_circles=10, circle_slice=1,
-                          circle_coverage=2 * np.pi):
+def radial_grid_positions(
+        init_radius,
+        final_radius,
+        init_position=np.zeros(2),
+        n_circles=10,
+        circle_slice=1,
+        circle_coverage=2 * np.pi
+):
     """
     Generate a 2D grid of positions in a radial pattern.
+
     Parameters
     ----------
     init_radius: float
@@ -175,6 +181,7 @@ def radial_grid_positions(init_radius, final_radius, init_position=np.zeros(2),
         number of points in each circle
     circle_coverage: float, default 2*pi
         coverage of each circle in radians (range: 0 to 2*pi)
+
     Returns
     -------
     grid_positions: numpy.ndarray(n_circles * circle_slice, 2)
@@ -192,10 +199,15 @@ def radial_grid_positions(init_radius, final_radius, init_position=np.zeros(2),
     return np.asarray(grid_positions)
 
 
-def spherical_grid_positions(init_radius, final_radius,
-                             init_position=np.zeros(3), n_circles=10,
-                             circle_slice=1,
-                             circle_coverage=2 * np.pi, z_coverage=np.pi):
+def spherical_grid_positions(
+        init_radius,
+        final_radius,
+        init_position=np.zeros(3),
+        n_circles=10,
+        circle_slice=1,
+        circle_coverage=2 * np.pi,
+        z_coverage=np.pi
+):
     """
     Generate a 3D grid of positions in a spherical pattern.
     Parameters

--- a/cmeutils/geometry.py
+++ b/cmeutils/geometry.py
@@ -85,7 +85,7 @@ def angle_between_vectors(u, v, min_angle=True, degrees=True):
     """
     # Angle in radians
     angle = np.arccos(u.dot(v) / (np.linalg.norm(u) * np.linalg.norm(v)))
-    if angle > np.pi/2 and min_angle:
+    if angle > np.pi / 2 and min_angle:
         angle = np.pi - angle
 
     if degrees:
@@ -112,16 +112,16 @@ def dihedral_angle(pos1, pos2, pos3, pos4, degrees=False):
     v2 = pos3 - pos2
     v3 = pos4 - pos3
     a1 = np.cross(v1, v2)
-    a1 = a1 / (a1*a1).sum(-1)**0.5
+    a1 = a1 / (a1 * a1).sum(-1) ** 0.5
     a2 = np.cross(v2, v3)
-    a2 = a2 / (a2*a2).sum(-1)**0.5
-    porm = np.sign((a1*v3).sum(-1))
-    phi = np.arccos((a1*a2).sum(-1) / ((a1**2).sum(-1) * (a2**2).sum(-1))**0.5)
+    a2 = a2 / (a2 * a2).sum(-1) ** 0.5
+    porm = np.sign((a1 * v3).sum(-1))
+    phi = np.arccos((a1 * a2).sum(-1) / ((a1 ** 2).sum(-1) * (a2 ** 2).sum(-1)) ** 0.5)
     if porm != 0:
         phi = phi * porm
     if degrees:
         phi = np.rad2deg(phi)
-    return phi 
+    return phi
 
 
 def moit(points, masses, center=np.zeros(3)):
@@ -153,3 +153,66 @@ def moit(points, masses, center=np.zeros(3)):
     I_yy = np.sum((x ** 2 + z ** 2) * masses)
     I_zz = np.sum((x ** 2 + y ** 2) * masses)
     return np.array((I_xx, I_yy, I_zz))
+
+
+def radial_grid_positions(init_radius, final_radius, init_position=np.zeros(2), n_circles=10, circle_slice=1,
+                          circle_coverage=2 * np.pi):
+    """
+    Generate a 2D grid of positions in a radial pattern.
+    Parameters
+    ----------
+    init_radius: initial radius of the grid (first circle).
+    final_radius: final radius of the grid (last circle).
+    init_position: initial position of the grid (center of the first circle).
+    n_circles: number of circles in the grid.
+    circle_slice: number of points in each circle.
+    circle_coverage: coverage of each circle in radians (range: 0 to 2*pi).
+
+    Returns
+    -------
+    grid_positions: numpy.ndarray, shape (n_circles * circle_slice, 2)
+        xy coordinates of the grid positions.
+    """
+
+    grid_positions = []
+    for radius in np.linspace(init_radius, final_radius, n_circles):
+        for d_theta in np.linspace(0, circle_coverage, circle_slice):
+            grid_positions.append((init_position[0] + np.round(radius * np.cos(d_theta), decimals=3),
+                                   init_position[1] + np.round(radius * np.sin(d_theta), decimals=3)))
+
+    return np.asarray(grid_positions)
+
+
+def spherical_grid_positions(init_radius, final_radius, init_position=np.zeros(3), n_circles=10, circle_slice=1,
+                             circle_coverage=2 * np.pi, z_coverage=np.pi):
+    """
+    Generate a 3D grid of positions in a spherical pattern.
+    Parameters
+    ----------
+    init_radius: initial radius of the grid (first circle).
+    final_radius: final radius of the grid (last circle).
+    init_position: initial position of the grid (center of the first circle).
+    n_circles: number of circles in the grid.
+    circle_slice: number of points in each circle.
+    circle_coverage: coverage of each circle in radians (range: 0 to 2*pi).
+    z_coverage: coverage of the z axis in radians (range: 0 to pi).
+
+    Returns
+    -------
+    grid_positions: numpy.ndarray
+        xyz coordinates of the grid positions.
+    """
+
+    z_slice = circle_slice * 2
+    grid_positions = []
+    for radius in np.linspace(init_radius, final_radius, n_circles):
+        for d_theta in np.linspace(0, circle_coverage, circle_slice):
+            for d_phi in np.linspace(0, z_coverage, z_slice):
+                x = init_position[0] + np.round(radius * np.cos(d_theta) * np.sin(d_phi), decimals=3)
+                y = init_position[1] + np.round(radius * np.sin(d_theta) * np.sin(d_phi), decimals=3)
+                z = init_position[2] + np.round(radius * np.cos(d_phi), decimals=3)
+                if not (x, y, z) in grid_positions:
+                    grid_positions.append((x, y, z))
+
+    return np.asarray(grid_positions)
+

--- a/cmeutils/gsd_utils.py
+++ b/cmeutils/gsd_utils.py
@@ -9,11 +9,11 @@ from cmeutils.geometry import moit
 
 
 def get_type_position(
-    typename,
-    gsd_file=None,
-    snap=None,
-    gsd_frame=-1,
-    images=False
+        typename,
+        gsd_file=None,
+        snap=None,
+        gsd_frame=-1,
+        images=False
 ):
     """Get the positions of a particle type.
 
@@ -51,15 +51,15 @@ def get_type_position(
     type_images = []
     for _type in typename:
         type_pos.extend(
-                snap.particles.position[
+            snap.particles.position[
                 snap.particles.typeid == snap.particles.types.index(_type)
-            ]
+                ]
         )
         if images:
             type_images.extend(
                 snap.particles.image[
                     snap.particles.typeid == snap.particles.types.index(_type)
-                ]
+                    ]
             )
     if images:
         return np.array(type_pos), np.array(type_images)
@@ -168,7 +168,7 @@ def snap_delete_types(snap, delete_types):
         i for i in snap.particles.types if i not in delete_types
     ]
     typeid_map = {
-        i:new_snap.particles.types.index(e)
+        i: new_snap.particles.types.index(e)
         for i, e in enumerate(snap.particles.types)
         if e in new_snap.particles.types
     }
@@ -181,7 +181,7 @@ def snap_delete_types(snap, delete_types):
     if snap.bonds.N > 0:
         bonds = np.isin(snap.bonds.group, selection).all(axis=1)
         if bonds.any():
-            inds = {e:i for i, e in enumerate(selection)}
+            inds = {e: i for i, e in enumerate(selection)}
             new_snap.bonds.group = np.vectorize(inds.get)(
                 snap.bonds.group[bonds]
             )
@@ -241,34 +241,34 @@ def update_rigid_snapshot(snapshot, mb_compound):
     rigid_bodies = set(rigid_ids)
     # Total number of rigid body particles
     N_mols = len(rigid_bodies)
-    N_p =  [rigid_ids.count(i) for i in rigid_bodies]
-	# Right now, we're assuming each molecule has the same num of particles
+    N_p = [rigid_ids.count(i) for i in rigid_bodies]
+    # Right now, we're assuming each molecule has the same num of particles
     assert len(set(N_p)) == 1
-    N_p = N_p[0] # Number of particles per molecule
+    N_p = N_p[0]  # Number of particles per molecule
     mol_inds = [
         np.arange(N_mols + i * N_p, N_mols + i * N_p + N_p)
         for i in range(N_mols)
     ]
 
     for i, inds in enumerate(mol_inds):
-	    total_mass = np.sum(snapshot.particles.mass[inds])
-	    com = (
-		    np.sum(
-			    snapshot.particles.position[inds]
-			    * snapshot.particles.mass[inds, np.newaxis],
-                axis=0,
-		    )
-		    / total_mass
-	    )
-	    snapshot.particles.position[i] = com
-	    snapshot.particles.body[i] = i
-	    snapshot.particles.body[inds] = i * np.ones_like(inds)
-	    snapshot.particles.mass[i] = np.sum(snapshot.particles.mass[inds])
-	    snapshot.particles.moment_inertia[i] = moit(
-		    snapshot.particles.position[inds],
-		    snapshot.particles.mass[inds],
-		    center=com,
-	    )
+        total_mass = np.sum(snapshot.particles.mass[inds])
+        com = (
+                np.sum(
+                    snapshot.particles.position[inds]
+                    * snapshot.particles.mass[inds, np.newaxis],
+                    axis=0,
+                )
+                / total_mass
+        )
+        snapshot.particles.position[i] = com
+        snapshot.particles.body[i] = i
+        snapshot.particles.body[inds] = i * np.ones_like(inds)
+        snapshot.particles.mass[i] = np.sum(snapshot.particles.mass[inds])
+        snapshot.particles.moment_inertia[i] = moit(
+            snapshot.particles.position[inds],
+            snapshot.particles.mass[inds],
+            center=com,
+        )
 
     rigid = hoomd.md.constrain.Rigid()
     inds = mol_inds[0]
@@ -277,19 +277,19 @@ def update_rigid_snapshot(snapshot, mb_compound):
     c_pos -= r_pos
     c_pos = [tuple(i) for i in c_pos]
     c_types = [
-            snapshot.particles.types[i] for i in snapshot.particles.typeid[inds]
+        snapshot.particles.types[i] for i in snapshot.particles.typeid[inds]
     ]
     c_orient = [tuple(i) for i in snapshot.particles.orientation[inds]]
     c_charge = [i for i in snapshot.particles.charge[inds]]
     c_diam = [i for i in snapshot.particles.diameter[inds]]
 
     rigid.body["R"] = {
-            "constituent_types": c_types,
-            "positions": c_pos,
-            "charges": c_charge,
-            "orientations": c_orient,
-            "diameters": c_diam,
-    } 
+        "constituent_types": c_types,
+        "positions": c_pos,
+        "charges": c_charge,
+        "orientations": c_orient,
+        "diameters": c_diam,
+    }
     return snapshot, rigid
 
 
@@ -325,7 +325,7 @@ def ellipsoid_gsd(gsd_file, new_file, lpar, lperp):
                         "type": "Sphere",
                         "diameter": 0.01
                     },
-                                  {
+                    {
                         "type": "Sphere",
                         "diameter": 0.01
                     }
@@ -352,7 +352,7 @@ def xml_to_gsd(xmlfile, gsdfile):
         import hoomd.deprecated
     except ImportError:
         raise ImportError(
-                "You must have hoomd version 2 installed to use xml_to_gsd()"
+            "You must have hoomd version 2 installed to use xml_to_gsd()"
         )
 
     hoomd.util.quiet_status()
@@ -370,7 +370,7 @@ def xml_to_gsd(xmlfile, gsdfile):
         with gsd.hoomd.open(f.name) as t, gsd.hoomd.open(gsdfile, "wb") as newt:
             snap = t[0]
             bonds = snap.bonds.group
-            bonds = bonds[np.lexsort((bonds[:,1], bonds[:,0]))]
+            bonds = bonds[np.lexsort((bonds[:, 1], bonds[:, 0]))]
             snap.bonds.group = bonds
             newt.append(snap)
     print(f"XML data written to {gsdfile}")

--- a/cmeutils/plotting.py
+++ b/cmeutils/plotting.py
@@ -31,21 +31,21 @@ def get_histogram(data, normalize=False, bins="auto", x_range=None):
     """
     bin_heights, bin_borders = np.histogram(data, bins=bins, range=x_range)
     if normalize is True:
-        bin_heights = bin_heights/sum(bin_heights)
+        bin_heights = bin_heights / sum(bin_heights)
     bin_widths = np.diff(bin_borders)
     bin_centers = bin_borders[:-1] + bin_widths / 2
     return bin_centers, bin_heights
 
-def threedplot(
-    x,
-    y,
-    z,
-    xlabel = "xlabel",
-    ylabel = "ylabel",
-    zlabel = "zlabel",
-    plot_name = "plot_name"
-    ):
 
+def threedplot(
+        x,
+        y,
+        z,
+        xlabel="xlabel",
+        ylabel="ylabel",
+        zlabel="zlabel",
+        plot_name="plot_name"
+):
     '''Plot a 3d heat map from 3 lists of numbers. This function is useful
     for plotting a dependent variable as a function of two independent variables.
     In the example below we use f(x,y)= -x^2 - y^2 +6 because it looks cool.
@@ -86,12 +86,12 @@ def threedplot(
 
 
     '''
-    fig = plt.figure(figsize = (10, 10), facecolor = 'white')
+    fig = plt.figure(figsize=(10, 10), facecolor='white')
     ax = plt.axes(projection='3d')
-    ax.set_xlabel(xlabel,fontdict=dict(weight='bold'),fontsize=12)
-    ax.set_ylabel(ylabel,fontdict=dict(weight='bold'),fontsize=12)
-    ax.set_zlabel(zlabel,fontdict=dict(weight='bold'),fontsize=12)
+    ax.set_xlabel(xlabel, fontdict=dict(weight='bold'), fontsize=12)
+    ax.set_ylabel(ylabel, fontdict=dict(weight='bold'), fontsize=12)
+    ax.set_zlabel(zlabel, fontdict=dict(weight='bold'), fontsize=12)
     p = ax.scatter(x, y, z, c=z, cmap='rainbow', linewidth=7);
-    plt.colorbar(p, pad = .1, aspect = 2.3)
+    plt.colorbar(p, pad=.1, aspect=2.3)
 
     return fig

--- a/cmeutils/sampling.py
+++ b/cmeutils/sampling.py
@@ -1,9 +1,10 @@
 import numpy as np
 from pymbar import timeseries
 
+
 def equil_sample(
         data, threshold_fraction=0.0, threshold_neff=1, conservative=True
-    ):
+):
     """Returns a statistically independent subset of an array of data.
 
     Parameters
@@ -27,15 +28,15 @@ def equil_sample(
 
     """
     is_equil, prod_start, ineff, Neff = is_equilibrated(
-            data, threshold_fraction, threshold_neff
+        data, threshold_fraction, threshold_neff
     )
 
     if is_equil:
         uncorr_indices = timeseries.subsample_correlated_data(
-                data[prod_start:], g=ineff, conservative=conservative
+            data[prod_start:], g=ineff, conservative=conservative
         )
         uncorr_sample = data[prod_start:][uncorr_indices]
-        return(uncorr_sample, uncorr_indices, prod_start, Neff)
+        return (uncorr_sample, uncorr_indices, prod_start, Neff)
 
     else:
         raise ValueError(
@@ -43,6 +44,7 @@ def equil_sample(
             "expected. More production data is needed, or the threshold needs "
             "to be lowered. See is_equilibrated for more information."
         )
+
 
 def is_equilibrated(data, threshold_fraction=0.50, threshold_neff=50, nskip=1):
     """Check if a dataset is equilibrated based on a fraction of equil data.

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -8,7 +8,7 @@ from rowan import vector_vector_rotation
 
 from cmeutils import gsd_utils
 from cmeutils.geometry import (
-        get_plane_normal, angle_between_vectors, dihedral_angle
+    get_plane_normal, angle_between_vectors, dihedral_angle
 )
 from cmeutils.plotting import get_histogram
 
@@ -84,10 +84,10 @@ def angle_distribution(
     for snap in trajectory[start: stop]:
         if name not in snap.angles.types and name_rev not in snap.angles.types:
             raise ValueError(
-                    f"Angles {name} or {name_rev} not found in "
-                    " snap.angles.types. "
-                    "A_name, B_name, C_name must match the order "
-                    "as they appear in snap.angles.types."
+                f"Angles {name} or {name_rev} not found in "
+                " snap.angles.types. "
+                "A_name, B_name, C_name must match the order "
+                "as they appear in snap.angles.types."
             )
         for idx, angle_id in enumerate(snap.angles.typeid):
             angle_name = snap.angles.types[angle_id]
@@ -104,22 +104,22 @@ def angle_distribution(
                 u = pos1_unwrap - pos2_unwrap
                 v = pos3_unwrap - pos2_unwrap
                 angles.append(
-                        np.round(angle_between_vectors(u, v, False, degrees), 3)
+                    np.round(angle_between_vectors(u, v, False, degrees), 3)
                 )
     trajectory.close()
 
     if histogram:
         if min(angles) < theta_min or max(angles) > theta_max:
             warnings.warn("There are bond angles that fall outside of "
-                    "your set theta_min and theta_max range. "
-                    "You may want to adjust this range to "
-                    "include all bond angles."
-            )
+                          "your set theta_min and theta_max range. "
+                          "You may want to adjust this range to "
+                          "include all bond angles."
+                          )
         bin_centers, bin_heights = get_histogram(
-                data=np.array(angles),
-                normalize=normalize,
-                bins=bins,
-                x_range=(theta_min, theta_max)
+            data=np.array(angles),
+            normalize=normalize,
+            bins=bins,
+            x_range=(theta_min, theta_max)
         )
         return np.stack((bin_centers, bin_heights)).T
     else:
@@ -127,16 +127,16 @@ def angle_distribution(
 
 
 def bond_distribution(
-    gsd_file,
-    A_name,
-    B_name,
-    start=0,
-    stop=-1,
-    histogram=False,
-    l_min=0.0,
-    l_max=4.0,
-    normalize=True,
-    bins=100
+        gsd_file,
+        A_name,
+        B_name,
+        start=0,
+        stop=-1,
+        histogram=False,
+        l_min=0.0,
+        l_max=4.0,
+        normalize=True,
+        bins=100
 ):
     """Returns the bond length distribution for a given bond pair 
     
@@ -184,8 +184,8 @@ def bond_distribution(
     for snap in trajectory[start:stop]:
         if name not in snap.bonds.types and name_rev not in snap.bonds.types:
             raise ValueError(f"Bond types {name} or {name_rev} not found "
-                    "snap.bonds.types."
-            )
+                             "snap.bonds.types."
+                             )
         for idx, bond in enumerate(snap.bonds.typeid):
             bond_name = snap.bonds.types[bond]
             if bond_name in [name, name_rev]:
@@ -196,21 +196,21 @@ def bond_distribution(
                 pos1_unwrap = pos1 + (img1 * snap.configuration.box[:3])
                 pos2_unwrap = pos2 + (img2 * snap.configuration.box[:3])
                 bonds.append(
-                        np.round(np.linalg.norm(pos2_unwrap - pos1_unwrap), 3)
+                    np.round(np.linalg.norm(pos2_unwrap - pos1_unwrap), 3)
                 )
     trajectory.close()
 
     if histogram:
         if min(bonds) < l_min or max(bonds) > l_max:
             warnings.warn("There are bond lengths that fall outside of "
-                    "your set l_min and l_max range. You may want to adjust "
-                    "this range to include all bond lengths."
-            )
+                          "your set l_min and l_max range. You may want to adjust "
+                          "this range to include all bond lengths."
+                          )
         bin_centers, bin_heights = get_histogram(
-                data = np.array(bonds),
-                normalize=normalize,
-                bins=bins,
-                x_range=(l_min, l_max)
+            data=np.array(bonds),
+            normalize=normalize,
+            bins=bins,
+            x_range=(l_min, l_max)
         )
         return np.stack((bin_centers, bin_heights)).T
     else:
@@ -277,10 +277,10 @@ def dihedral_distribution(
         if (name not in snap.dihedrals.types and
                 name_rev not in snap.dihedrals.types):
             raise ValueError(
-                    f"Dihedrals {name} or {name_rev} not found in "
-                    " snap.dihedrals.types. "
-                    "A_name, B_name, C_name, D_name must match the order "
-                    "as they appear in snap.dihedrals.types."
+                f"Dihedrals {name} or {name_rev} not found in "
+                " snap.dihedrals.types. "
+                "A_name, B_name, C_name, D_name must match the order "
+                "as they appear in snap.dihedrals.types."
             )
         for idx, _id in enumerate(snap.dihedrals.typeid):
             dih_name = snap.dihedrals.types[_id]
@@ -298,24 +298,24 @@ def dihedral_distribution(
                 pos3_unwrap = pos3 + (img3 * snap.configuration.box[:3])
                 pos4_unwrap = pos4 + (img4 * snap.configuration.box[:3])
                 phi = dihedral_angle(
-                        pos1_unwrap, pos2_unwrap, pos3_unwrap, pos4_unwrap
+                    pos1_unwrap, pos2_unwrap, pos3_unwrap, pos4_unwrap
                 )
                 dihedrals.append(phi)
     trajectory.close()
 
     if histogram:
         bin_centers, bin_heights = get_histogram(
-                data=np.array(dihedrals),
-                normalize=normalize,
-                bins=bins,
-                x_range=(-np.pi, np.pi)
+            data=np.array(dihedrals),
+            normalize=normalize,
+            bins=bins,
+            x_range=(-np.pi, np.pi)
         )
         return np.stack((bin_centers, bin_heights)).T
     else:
         return np.array(dihedrals)
 
 
-def get_quaternions(n_views = 20):
+def get_quaternions(n_views=20):
     """Get the quaternions for the specified number of views.
 
     The first (n_view - 3) views will be the views even distributed on a sphere,
@@ -335,17 +335,17 @@ def get_quaternions(n_views = 20):
     list of numpy.ndarray
         Quaternions as (4,) arrays.
     """
-    if n_views <=3 or not isinstance(n_views, int):
+    if n_views <= 3 or not isinstance(n_views, int):
         raise ValueError("Please set n_views to an integer greater than 3.")
     # Calculate points for even distribution on a sphere
-    ga = np.pi * (3 - 5**0.5)
-    theta = ga * np.arange(n_views-3)
-    z = np.linspace(1 - 1/(n_views-3), 1/(n_views-3), n_views-3)
+    ga = np.pi * (3 - 5 ** 0.5)
+    theta = ga * np.arange(n_views - 3)
+    z = np.linspace(1 - 1 / (n_views - 3), 1 / (n_views - 3), n_views - 3)
     radius = np.sqrt(1 - z * z)
     points = np.zeros((n_views, 3))
-    points[:-3,0] = radius * np.cos(theta)
-    points[:-3,1] = radius * np.sin(theta)
-    points[:-3,2] = z
+    points[:-3, 0] = radius * np.cos(theta)
+    points[:-3, 1] = radius * np.sin(theta)
+    points[:-3, 2] = z
 
     # face on
     points[-3] = np.array([0, 0, 1])
@@ -359,15 +359,15 @@ def get_quaternions(n_views = 20):
 
 
 def gsd_rdf(
-    gsdfile,
-    A_name,
-    B_name,
-    start=0,
-    stop=-1,
-    r_max=None,
-    r_min=0,
-    bins=100,
-    exclude_bonded=True,
+        gsdfile,
+        A_name,
+        B_name,
+        start=0,
+        stop=-1,
+        r_max=None,
+        r_min=0,
+        bins=100,
+        exclude_bonded=True,
 ):
     """Compute intermolecular RDF from a GSD file.
 
@@ -473,7 +473,8 @@ def get_centers(gsdfile, new_gsdfile):
     new_gsdfile : str
         Filename of new GSD for centers.
     """
-    with gsd.hoomd.open(new_gsdfile, 'wb') as new_traj, gsd.hoomd.open(gsdfile, 'rb') as traj:
+    with gsd.hoomd.open(new_gsdfile, 'wb') as new_traj, gsd.hoomd.open(gsdfile,
+                                                                       'rb') as traj:
         snap = traj[0]
         cluster_idx = gsd_utils.get_molecule_cluster(snap=snap)
         for snap in traj:
@@ -481,11 +482,12 @@ def get_centers(gsdfile, new_gsdfile):
             new_snap.configuration.box = snap.configuration.box
             f_box = freud.box.Box.from_box(snap.configuration.box)
             # Use the freud box to unwrap the particle positions
-            unwrapped_positions = f_box.unwrap(snap.particles.position, snap.particles.image)
+            unwrapped_positions = f_box.unwrap(snap.particles.position,
+                                               snap.particles.image)
             uw_centers = []
-            for i in range(max(cluster_idx)+1):
+            for i in range(max(cluster_idx) + 1):
                 cluster_uw_pos = unwrapped_positions[np.where(cluster_idx == i)]
-                uw_centers.append(np.mean(cluster_uw_pos, axis = 0))
+                uw_centers.append(np.mean(cluster_uw_pos, axis=0))
             uw_centers = np.stack(uw_centers)
             new_snap.particles.position = f_box.wrap(uw_centers)
             new_snap.particles.N = len(uw_centers)
@@ -564,7 +566,7 @@ def order_parameter(aa_gsd, cg_gsd, mapping, r_max, a_max, large=6, start=-10):
             aq = freud.locality.AABBQuery.from_system(cg_snap)
             n_list = aq.query(
                 cg_snap.particles.position,
-                query_args={"exclude_ii":True, "r_max": r_max}
+                query_args={"exclude_ii": True, "r_max": r_max}
             ).toNeighborList()
 
             vec_point = [
@@ -576,8 +578,8 @@ def order_parameter(aa_gsd, cg_gsd, mapping, r_max, a_max, large=6, start=-10):
                 for i in n_list.query_point_indices
             ]
             n_list.filter([
-                angle_between_vectors(i,j) < a_max
-                for i,j in zip(vec_point, vec_querypoint)
+                angle_between_vectors(i, j) < a_max
+                for i, j in zip(vec_point, vec_querypoint)
             ])
             cl = freud.cluster.Cluster()
             cl.compute(cg_snap, neighbors=n_list)
@@ -627,7 +629,7 @@ def all_atom_rdf(gsdfile,
     with gsd.hoomd.open(gsdfile, mode="rb") as trajectory:
         snap = trajectory[start]
         if r_max is None:
-            #Use a value just less than half the maximum box length.
+            # Use a value just less than half the maximum box length.
             r_max = np.nextafter(
                 np.max(snap.configuration.box[:3]) * 0.5, 0, dtype=np.float32
             )

--- a/cmeutils/tests/test_geometry.py
+++ b/cmeutils/tests/test_geometry.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from base_test import BaseTest
-from cmeutils.geometry import get_plane_normal, angle_between_vectors, moit
+from cmeutils.geometry import get_plane_normal, angle_between_vectors, moit, radial_grid_positions, spherical_grid_positions
 
 
 class TestGeometry(BaseTest):
@@ -46,5 +46,107 @@ class TestGeometry(BaseTest):
             angle_between_vectors(
                 np.array([1,0,0]),np.array([-1,0,0]), degrees=False
             )
+        )
+
+    def test_radial_grid_positions(self):
+        grid = radial_grid_positions(
+            init_radius=1, final_radius=2, init_position=np.zeros(2),
+            n_circles=2, circle_slice=2, circle_coverage=np.pi
+        )
+        assert np.array_equal(
+            grid,
+            np.array([
+                [1., 0.],
+                [-1., 0.],
+                [2., 0],
+                [-2, 0]
+            ])
+        )
+
+    def test_radial_grid_positions_quarter_circle(self):
+        grid = radial_grid_positions(
+            init_radius=1, final_radius=2, init_position=np.zeros(2),
+            n_circles=2, circle_slice=4, circle_coverage=np.pi/2
+        )
+        assert np.array_equal(
+            grid,
+            np.array([
+                [1., 0.],
+                [0.866, 0.5],
+                [0.5, 0.866],
+                [0., 1.],
+                [2., 0.],
+                [1.732, 1.],
+                [1., 1.732],
+                [0., 2.]
+            ])
+        )
+
+    def test_radial_grid_positions_along_x(self):
+        grid = radial_grid_positions(
+            init_radius=1, final_radius=3, init_position=np.zeros(2),
+            n_circles=3, circle_slice=1, circle_coverage=np.pi*2)
+        assert np.array_equal(
+            grid,
+            np.array([
+                [1., 0.],
+                [2., 0.],
+                [3., 0.]
+            ])
+        )
+
+    def test_radial_grid_positions_init_position(self):
+        grid = radial_grid_positions(
+            init_radius=1, final_radius=2, init_position=np.array([1, 1]),
+            n_circles=2, circle_slice=2, circle_coverage=np.pi)
+        assert np.array_equal(
+            grid,
+            np.array([
+                [2., 1.],
+                [0., 1.],
+                [3., 1.],
+                [-1., 1.]
+            ])
+        )
+
+    def test_spherical_grid_positions(self):
+        grid = spherical_grid_positions(
+            init_radius=1, final_radius=2, init_position=np.zeros(3),
+            n_circles=2, circle_slice=2, circle_coverage=np.pi, z_coverage=np.pi
+        )
+        assert np.array_equal(
+            grid,
+            np.array([
+                [0., 0., 1.],
+                [0.866, 0., 0.5],
+                [0.866, 0., -0.5],
+                [0., 0., -1.],
+                [-0.866, 0., 0.5],
+                [-0.866, 0., -0.5],
+                [0., 0., 2.],
+                [1.732, 0., 1.0],
+                [1.732, 0., -1.],
+                [0., 0., -2.],
+                [-1.732, 0., 1.],
+                [-1.732, 0., -1.]
+            ])
+        )
+
+    def test_spherical_grid_positions_half_circle(self):
+        grid = spherical_grid_positions(
+            init_radius=1, final_radius=1, init_position=np.zeros(3),
+            n_circles=2, circle_slice=2, circle_coverage=np.pi, z_coverage=np.pi/2
+        )
+        assert np.array_equal(
+            grid,
+            np.array([
+                [0., 0., 1.],
+                [0.5, 0, 0.866],
+                [0.866, 0., 0.5],
+                [1, 0., 0.],
+                [-0.5, 0, 0.866],
+                [-0.866, 0., 0.5],
+                [-1., 0., 0.]
+            ])
         )
 

--- a/cmeutils/tests/test_geometry.py
+++ b/cmeutils/tests/test_geometry.py
@@ -52,23 +52,26 @@ class TestGeometry(BaseTest):
 
     def test_radial_grid_positions(self):
         grid = radial_grid_positions(
-            init_radius=1, final_radius=2, init_position=np.zeros(2),
-            n_circles=2, circle_slice=2, circle_coverage=np.pi
+            init_radius=1,
+            final_radius=2,
+            init_position=np.zeros(2),
+            n_circles=2,
+            circle_slice=2,
+            circle_coverage=np.pi
         )
         assert np.array_equal(
             grid,
-            np.array([
-                [1., 0.],
-                [-1., 0.],
-                [2., 0],
-                [-2, 0]
-            ])
+            np.array([[1., 0.], [-1., 0.], [2., 0], [-2, 0]])
         )
 
     def test_radial_grid_positions_quarter_circle(self):
         grid = radial_grid_positions(
-            init_radius=1, final_radius=2, init_position=np.zeros(2),
-            n_circles=2, circle_slice=4, circle_coverage=np.pi / 2
+            init_radius=1,
+            final_radius=2,
+            init_position=np.zeros(2),
+            n_circles=2,
+            circle_slice=4,
+            circle_coverage=np.pi / 2
         )
         assert np.array_equal(
             grid,
@@ -86,21 +89,27 @@ class TestGeometry(BaseTest):
 
     def test_radial_grid_positions_along_x(self):
         grid = radial_grid_positions(
-            init_radius=1, final_radius=3, init_position=np.zeros(2),
-            n_circles=3, circle_slice=1, circle_coverage=np.pi * 2)
+            init_radius=1,
+            final_radius=3,
+            init_position=np.zeros(2),
+            n_circles=3,
+            circle_slice=1,
+            circle_coverage=np.pi * 2
+        )
         assert np.array_equal(
             grid,
-            np.array([
-                [1., 0.],
-                [2., 0.],
-                [3., 0.]
-            ])
+            np.array([[1., 0.], [2., 0.], [3., 0.]])
         )
 
     def test_radial_grid_positions_init_position(self):
         grid = radial_grid_positions(
-            init_radius=1, final_radius=2, init_position=np.array([1, 1]),
-            n_circles=2, circle_slice=2, circle_coverage=np.pi)
+            init_radius=1,
+            final_radius=2,
+            init_position=np.array([1, 1]),
+            n_circles=2,
+            circle_slice=2,
+            circle_coverage=np.pi
+        )
         assert np.array_equal(
             grid,
             np.array([
@@ -113,8 +122,13 @@ class TestGeometry(BaseTest):
 
     def test_spherical_grid_positions(self):
         grid = spherical_grid_positions(
-            init_radius=1, final_radius=2, init_position=np.zeros(3),
-            n_circles=2, circle_slice=2, circle_coverage=np.pi, z_coverage=np.pi
+            init_radius=1,
+            final_radius=2,
+            init_position=np.zeros(3),
+            n_circles=2,
+            circle_slice=2,
+            circle_coverage=np.pi,
+            z_coverage=np.pi
         )
         assert np.array_equal(
             grid,
@@ -136,8 +150,12 @@ class TestGeometry(BaseTest):
 
     def test_spherical_grid_positions_half_circle(self):
         grid = spherical_grid_positions(
-            init_radius=1, final_radius=1, init_position=np.zeros(3),
-            n_circles=2, circle_slice=2, circle_coverage=np.pi,
+            init_radius=1,
+            final_radius=1,
+            init_position=np.zeros(3),
+            n_circles=2,
+            circle_slice=2,
+            circle_coverage=np.pi,
             z_coverage=np.pi / 2
         )
         assert np.array_equal(

--- a/cmeutils/tests/test_geometry.py
+++ b/cmeutils/tests/test_geometry.py
@@ -4,7 +4,9 @@ import numpy as np
 import pytest
 
 from base_test import BaseTest
-from cmeutils.geometry import get_plane_normal, angle_between_vectors, moit, radial_grid_positions, spherical_grid_positions
+from cmeutils.geometry import get_plane_normal, angle_between_vectors, moit, \
+    radial_grid_positions, \
+    spherical_grid_positions
 
 
 class TestGeometry(BaseTest):
@@ -14,10 +16,10 @@ class TestGeometry(BaseTest):
 
     def test_get_plane_normal(self):
         points = np.array(
-            [[ 1, 0, 0],
-             [ 0, 1, 0],
+            [[1, 0, 0],
+             [0, 1, 0],
              [-1, 0, 0],
-             [ 0,-1, 0]]
+             [0, -1, 0]]
         )
         ctr, norm = get_plane_normal(points)
         assert np.allclose(ctr, np.array([0, 0, 0]))
@@ -28,23 +30,23 @@ class TestGeometry(BaseTest):
 
     def test_angle_between_vectors_deg(self):
         assert np.isclose(
-            90, angle_between_vectors(np.array([1,0,0]),np.array([0,1,0]))
+            90, angle_between_vectors(np.array([1, 0, 0]), np.array([0, 1, 0]))
         )
         assert np.isclose(
-            0, angle_between_vectors(np.array([1,0,0]),np.array([-1,0,0]))
+            0, angle_between_vectors(np.array([1, 0, 0]), np.array([-1, 0, 0]))
         )
 
     def test_angle_between_vectors_rad(self):
         assert np.isclose(
-            math.pi/2,
+            math.pi / 2,
             angle_between_vectors(
-                np.array([1,0,0]),np.array([0,1,0]), degrees=False
+                np.array([1, 0, 0]), np.array([0, 1, 0]), degrees=False
             )
         )
         assert np.isclose(
             0,
             angle_between_vectors(
-                np.array([1,0,0]),np.array([-1,0,0]), degrees=False
+                np.array([1, 0, 0]), np.array([-1, 0, 0]), degrees=False
             )
         )
 
@@ -66,7 +68,7 @@ class TestGeometry(BaseTest):
     def test_radial_grid_positions_quarter_circle(self):
         grid = radial_grid_positions(
             init_radius=1, final_radius=2, init_position=np.zeros(2),
-            n_circles=2, circle_slice=4, circle_coverage=np.pi/2
+            n_circles=2, circle_slice=4, circle_coverage=np.pi / 2
         )
         assert np.array_equal(
             grid,
@@ -85,7 +87,7 @@ class TestGeometry(BaseTest):
     def test_radial_grid_positions_along_x(self):
         grid = radial_grid_positions(
             init_radius=1, final_radius=3, init_position=np.zeros(2),
-            n_circles=3, circle_slice=1, circle_coverage=np.pi*2)
+            n_circles=3, circle_slice=1, circle_coverage=np.pi * 2)
         assert np.array_equal(
             grid,
             np.array([
@@ -135,7 +137,8 @@ class TestGeometry(BaseTest):
     def test_spherical_grid_positions_half_circle(self):
         grid = spherical_grid_positions(
             init_radius=1, final_radius=1, init_position=np.zeros(3),
-            n_circles=2, circle_slice=2, circle_coverage=np.pi, z_coverage=np.pi/2
+            n_circles=2, circle_slice=2, circle_coverage=np.pi,
+            z_coverage=np.pi / 2
         )
         assert np.array_equal(
             grid,
@@ -149,4 +152,3 @@ class TestGeometry(BaseTest):
                 [-1., 0., 0.]
             ])
         )
-

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - freud
   - gsd=2.9
-  - hoomd>3.0=*cpu*
+  - hoomd<4.0=*cpu*
   - mbuild
   - numpy
   - pip

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - freud
-  - gsd
+  - gsd=2.9
   - hoomd>3.0=*cpu*
   - mbuild
   - numpy


### PR DESCRIPTION
This PR adds the following functions to the geometry file:

1) `radial_grid_positions`: returns a radial grid of 2D positions between two radii.  Number of circles between the two radii, number of points in each circle and the coverage angle of each circle can be customized.

2) `spherical_grid_positions`: returns a spherical grid of 3D positions between two radii and an angle along z axis. Number of circles between the two radii, number of points in each circle and the coverage angle of each circle can be customized.

These functions can be useful when a fixed set of positions needs to be swipped in a simulation.