### PR TITLE
Setting up pre-commit hooks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
     # Run when container or environment is changed
     paths:
         - 'containers/dockerfile'
-        - 'environment.yml'
+        - 'environment-dev.yml'
   # Allows workflow to be manually triggered
   workflow_dispatch:
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,13 +5,13 @@ on:
     branches: [ master ]
     paths:
       - 'cmeutils/**'
-      - environment.yml
+      - environment-dev.yml
       - .github/workflows/pytest.yml
   pull_request:
     branches: [ master ]
     paths:
       - 'cmeutils/**'
-      - environment.yml
+      - environment-dev.yml
       - .github/workflows/pytest.yml
   # Allows workflow to be manually triggered
   workflow_dispatch:
@@ -27,9 +27,9 @@ jobs:
     - name: Build environment
       uses: conda-incubator/setup-miniconda@v2
       with:
-        environment-file: environment.yml
+        environment-file: environment-dev.yml
         miniforge-variant: Mambaforge
-        miniforge-version: 4.9.2-4
+        miniforge-version: 23.1.0-4 
         use-mamba: true
 
     - name: Install package

--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ dmypy.json
 
 # Other stuff
 *.gsd
+
+# IDE files
+.idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,4 +27,3 @@ repos:
     - id: flake8
       args:
         - --max-line-length=80
-      exclude: 'cmeuitls/tests/'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,10 @@ repos:
     - id: flake8
       args:
         - --max-line-length=80
+
+#- repo: https://github.com/pycqa/pydocstyle
+#  rev: '6.3.0'
+#  hooks:
+#    - id: pydocstyle
+#      exclude: ^(cmeuitls/tests/|setup.py)
+#      args: [--convention=numpy]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+default_stages: [ commit ]
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.4.0
+  hooks:
+    - id: check-yaml
+    - id: end-of-file-fixer
+    - id: trailing-whitespace
+      exclude: 'cmeuitls/tests/assets/.*'
+- repo: https://github.com/psf/black
+  rev: 23.7.0
+  hooks:
+    - id: black
+      args: [--line-length=80]
+- repo: https://github.com/pycqa/isort
+  rev: 5.12.0
+  hooks:
+    - id: isort
+      name: isort (python)
+      args:
+        [--profile=black, --line-length=80]
+      exclude: 'cmeuitls/tests/assets/.* '
+
+- repo: https://github.com/pycqa/flake8
+  rev: 6.1.0
+  hooks:
+    - id: flake8
+      args:
+        - --max-line-length=80
+      exclude: 'cmeuitls/tests/'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,14 @@
+ci:
+    autofix_commit_msg: |
+        [pre-commit.ci] auto fixes from pre-commit.com hooks
+
+        for more information, see https://pre-commit.ci
+    autofix_prs: true
+    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+    autoupdate_schedule: weekly
+    skip: []
+    submodules: false
+
 default_stages: [ commit ]
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/cmeutils/dynamics.py
+++ b/cmeutils/dynamics.py
@@ -1,18 +1,15 @@
+from warnings import warn
+
 import freud
 import gsd
 import gsd.hoomd
 import numpy as np
-from warnings import warn
 
 from cmeutils import gsd_utils
 
 
 def msd_from_gsd(
-        gsdfile,
-        atom_types="all",
-        start=0,
-        stop=-1,
-        msd_mode="window"
+    gsdfile, atom_types="all", start=0, stop=-1, msd_mode="window"
 ):
     """Calculate the mean-square displacement (MSD) of the particles in a
     trajectory using Freud.
@@ -48,9 +45,7 @@ def msd_from_gsd(
                 atom_img = frame.particles.image[:]
             else:
                 atom_pos, atom_img = gsd_utils.get_type_position(
-                    atom_types,
-                    snap=frame,
-                    images=True
+                    atom_types, snap=frame, images=True
                 )
             positions.append(atom_pos)
             images.append(atom_img)

--- a/cmeutils/geometry.py
+++ b/cmeutils/geometry.py
@@ -117,7 +117,8 @@ def dihedral_angle(pos1, pos2, pos3, pos4, degrees=False):
     a2 = a2 / (a2 * a2).sum(-1) ** 0.5
     porm = np.sign((a1 * v3).sum(-1))
     phi = np.arccos(
-        (a1 * a2).sum(-1) / ((a1 ** 2).sum(-1) * (a2 ** 2).sum(-1)) ** 0.5)
+        (a1 * a2).sum(-1) / ((a1**2).sum(-1) * (a2**2).sum(-1)) ** 0.5
+    )
     if porm != 0:
         phi = phi * porm
     if degrees:
@@ -126,8 +127,8 @@ def dihedral_angle(pos1, pos2, pos3, pos4, degrees=False):
 
 
 def moit(points, masses, center=np.zeros(3)):
-    """Calculates moment of inertia tensor (moit) for rigid bodies. 
-    
+    """Calculates moment of inertia tensor (moit) for rigid bodies.
+
     Assumes rigid body center is at origin unless center is provided.
     Only calculates diagonal elements.
 
@@ -139,7 +140,7 @@ def moit(points, masses, center=np.zeros(3)):
         masses of the constituent particles
     center : numpy.ndarray (3,), default np.array([0,0,0])
         x, y, and z coordinates of the rigid body center
-        
+
     Returns
     -------
     numpy.ndarray (3,)
@@ -150,19 +151,19 @@ def moit(points, masses, center=np.zeros(3)):
     x = points[:, 0]
     y = points[:, 1]
     z = points[:, 2]
-    I_xx = np.sum((y ** 2 + z ** 2) * masses)
-    I_yy = np.sum((x ** 2 + z ** 2) * masses)
-    I_zz = np.sum((x ** 2 + y ** 2) * masses)
+    I_xx = np.sum((y**2 + z**2) * masses)
+    I_yy = np.sum((x**2 + z**2) * masses)
+    I_zz = np.sum((x**2 + y**2) * masses)
     return np.array((I_xx, I_yy, I_zz))
 
 
 def radial_grid_positions(
-        init_radius,
-        final_radius,
-        init_position=np.zeros(2),
-        n_circles=10,
-        circle_slice=1,
-        circle_coverage=2 * np.pi
+    init_radius,
+    final_radius,
+    init_position=np.zeros(2),
+    n_circles=10,
+    circle_slice=1,
+    circle_coverage=2 * np.pi,
 ):
     """
     Generate a 2D grid of positions in a radial pattern.
@@ -191,22 +192,26 @@ def radial_grid_positions(
     grid_positions = []
     for radius in np.linspace(init_radius, final_radius, n_circles):
         for d_theta in np.linspace(0, circle_coverage, circle_slice):
-            grid_positions.append((init_position[0] + np.round(
-                radius * np.cos(d_theta), decimals=3),
-                                   init_position[1] + np.round(
-                                       radius * np.sin(d_theta), decimals=3)))
+            grid_positions.append(
+                (
+                    init_position[0]
+                    + np.round(radius * np.cos(d_theta), decimals=3),
+                    init_position[1]
+                    + np.round(radius * np.sin(d_theta), decimals=3),
+                )
+            )
 
     return np.asarray(grid_positions)
 
 
 def spherical_grid_positions(
-        init_radius,
-        final_radius,
-        init_position=np.zeros(3),
-        n_circles=10,
-        circle_slice=1,
-        circle_coverage=2 * np.pi,
-        z_coverage=np.pi
+    init_radius,
+    final_radius,
+    init_position=np.zeros(3),
+    n_circles=10,
+    circle_slice=1,
+    circle_coverage=2 * np.pi,
+    z_coverage=np.pi,
 ):
     """
     Generate a 3D grid of positions in a spherical pattern.
@@ -239,11 +244,14 @@ def spherical_grid_positions(
         for d_theta in np.linspace(0, circle_coverage, circle_slice):
             for d_phi in np.linspace(0, z_coverage, z_slice):
                 x = init_position[0] + np.round(
-                    radius * np.cos(d_theta) * np.sin(d_phi), decimals=3)
+                    radius * np.cos(d_theta) * np.sin(d_phi), decimals=3
+                )
                 y = init_position[1] + np.round(
-                    radius * np.sin(d_theta) * np.sin(d_phi), decimals=3)
-                z = init_position[2] + np.round(radius * np.cos(d_phi),
-                                                decimals=3)
+                    radius * np.sin(d_theta) * np.sin(d_phi), decimals=3
+                )
+                z = init_position[2] + np.round(
+                    radius * np.cos(d_phi), decimals=3
+                )
                 if not (x, y, z) in grid_positions:
                     grid_positions.append((x, y, z))
 

--- a/cmeutils/gsd_utils.py
+++ b/cmeutils/gsd_utils.py
@@ -9,11 +9,7 @@ from cmeutils.geometry import moit
 
 
 def get_type_position(
-        typename,
-        gsd_file=None,
-        snap=None,
-        gsd_frame=-1,
-        images=False
+    typename, gsd_file=None, snap=None, gsd_frame=-1, images=False
 ):
     """Get the positions of a particle type.
 
@@ -53,13 +49,13 @@ def get_type_position(
         type_pos.extend(
             snap.particles.position[
                 snap.particles.typeid == snap.particles.types.index(_type)
-                ]
+            ]
         )
         if images:
             type_images.extend(
                 snap.particles.image[
                     snap.particles.typeid == snap.particles.types.index(_type)
-                    ]
+                ]
             )
     if images:
         return np.array(type_pos), np.array(type_images)
@@ -195,7 +191,7 @@ def create_rigid_snapshot(mb_compound):
 
     This method relies on using built-in mBuild methods to
     create the rigid body information.
-    
+
     Parameters
     ----------
     mb_compound : mbuild.Compound, required
@@ -253,12 +249,12 @@ def update_rigid_snapshot(snapshot, mb_compound):
     for i, inds in enumerate(mol_inds):
         total_mass = np.sum(snapshot.particles.mass[inds])
         com = (
-                np.sum(
-                    snapshot.particles.position[inds]
-                    * snapshot.particles.mass[inds, np.newaxis],
-                    axis=0,
-                )
-                / total_mass
+            np.sum(
+                snapshot.particles.position[inds]
+                * snapshot.particles.mass[inds, np.newaxis],
+                axis=0,
+            )
+            / total_mass
         )
         snapshot.particles.position[i] = com
         snapshot.particles.body[i] = i
@@ -297,11 +293,11 @@ def ellipsoid_gsd(gsd_file, new_file, lpar, lperp):
     """Add needed information to GSD file to visualize ellipsoids.
 
     Saves a new GSD file with lpar and lperp values populated
-    for each particle. Ovito can be used to visualize the new GSD file. 
-	
+    for each particle. Ovito can be used to visualize the new GSD file.
+
     Parameters
     ----------
-    gsd_file : str 
+    gsd_file : str
         Path to the original GSD file containing trajectory information
     new_file : str
         Path and filename of the new GSD file
@@ -309,26 +305,15 @@ def ellipsoid_gsd(gsd_file, new_file, lpar, lperp):
         Value of lpar of the ellipsoids
     lperp : float
         Value of lperp of the ellipsoids
-	
-	"""
+
+    """
     with gsd.hoomd.open(new_file, "wb") as new_t:
         with gsd.hoomd.open(gsd_file) as old_t:
             for snap in old_t:
                 snap.particles.type_shapes = [
-                    {
-                        "type": "Ellipsoid",
-                        "a": lpar,
-                        "b": lperp,
-                        "c": lperp
-                    },
-                    {
-                        "type": "Sphere",
-                        "diameter": 0.01
-                    },
-                    {
-                        "type": "Sphere",
-                        "diameter": 0.01
-                    }
+                    {"type": "Ellipsoid", "a": lpar, "b": lperp, "c": lperp},
+                    {"type": "Sphere", "diameter": 0.01},
+                    {"type": "Sphere", "diameter": 0.01},
                 ]
                 snap.validate()
                 new_t.append(snap)
@@ -364,7 +349,7 @@ def xml_to_gsd(xmlfile, gsdfile):
             period=None,
             group=hoomd.group.all(),
             dynamic=["momentum"],
-            overwrite=True
+            overwrite=True,
         )
         hoomd.util.unquiet_status()
         with gsd.hoomd.open(f.name) as t, gsd.hoomd.open(gsdfile, "wb") as newt:

--- a/cmeutils/plotting.py
+++ b/cmeutils/plotting.py
@@ -38,16 +38,17 @@ def get_histogram(data, normalize=False, bins="auto", x_range=None):
 
 
 def threedplot(
-        x,
-        y,
-        z,
-        xlabel="xlabel",
-        ylabel="ylabel",
-        zlabel="zlabel",
-        plot_name="plot_name"
+    x,
+    y,
+    z,
+    xlabel="xlabel",
+    ylabel="ylabel",
+    zlabel="zlabel",
+    plot_name="plot_name",
 ):
-    '''Plot a 3d heat map from 3 lists of numbers. This function is useful
-    for plotting a dependent variable as a function of two independent variables.
+    """Plot a 3d heat map from 3 lists of numbers. This function is useful
+    for plotting a dependent variable as a function of two independent
+    variables.
     In the example below we use f(x,y)= -x^2 - y^2 +6 because it looks cool.
 
     Example
@@ -85,13 +86,13 @@ def threedplot(
     plot_name : str
 
 
-    '''
-    fig = plt.figure(figsize=(10, 10), facecolor='white')
-    ax = plt.axes(projection='3d')
-    ax.set_xlabel(xlabel, fontdict=dict(weight='bold'), fontsize=12)
-    ax.set_ylabel(ylabel, fontdict=dict(weight='bold'), fontsize=12)
-    ax.set_zlabel(zlabel, fontdict=dict(weight='bold'), fontsize=12)
-    p = ax.scatter(x, y, z, c=z, cmap='rainbow', linewidth=7);
-    plt.colorbar(p, pad=.1, aspect=2.3)
+    """
+    fig = plt.figure(figsize=(10, 10), facecolor="white")
+    ax = plt.axes(projection="3d")
+    ax.set_xlabel(xlabel, fontdict=dict(weight="bold"), fontsize=12)
+    ax.set_ylabel(ylabel, fontdict=dict(weight="bold"), fontsize=12)
+    ax.set_zlabel(zlabel, fontdict=dict(weight="bold"), fontsize=12)
+    p = ax.scatter(x, y, z, c=z, cmap="rainbow", linewidth=7)
+    plt.colorbar(p, pad=0.1, aspect=2.3)
 
     return fig

--- a/cmeutils/sampling.py
+++ b/cmeutils/sampling.py
@@ -3,7 +3,7 @@ from pymbar import timeseries
 
 
 def equil_sample(
-        data, threshold_fraction=0.0, threshold_neff=1, conservative=True
+    data, threshold_fraction=0.0, threshold_neff=1, conservative=True
 ):
     """Returns a statistically independent subset of an array of data.
 
@@ -18,7 +18,7 @@ def equil_sample(
         'equilibrated'.
     conservative : bool, default=True
         if set to True, uniformly-spaced indices are chosen with interval
-        ceil(g), where g is the statistical inefficiency.  
+        ceil(g), where g is the statistical inefficiency.
         Otherwise, indices are chosen non-uniformly with interval of
         approximately g in order to end up with approximately T/g total indices
 

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -8,33 +8,35 @@ from rowan import vector_vector_rotation
 
 from cmeutils import gsd_utils
 from cmeutils.geometry import (
-    get_plane_normal, angle_between_vectors, dihedral_angle
+    angle_between_vectors,
+    dihedral_angle,
+    get_plane_normal,
 )
 from cmeutils.plotting import get_histogram
 
 
 def angle_distribution(
-        gsd_file,
-        A_name,
-        B_name,
-        C_name,
-        start=0,
-        stop=-1,
-        degrees=False,
-        histogram=False,
-        theta_min=0.0,
-        theta_max=None,
-        normalize=False,
-        bins="auto"
+    gsd_file,
+    A_name,
+    B_name,
+    C_name,
+    start=0,
+    stop=-1,
+    degrees=False,
+    histogram=False,
+    theta_min=0.0,
+    theta_max=None,
+    normalize=False,
+    bins="auto",
 ):
-    """Returns the bond angle distribution for a given triplet of particles 
-    
+    """Returns the bond angle distribution for a given triplet of particles
+
     Parameters
     ----------
     gsdfile : str
         Filename of the GSD trajectory.
     A_name, B_name, C_name : str
-        Name(s) of particles that form the angle triplet 
+        Name(s) of particles that form the angle triplet
         (found in gsd.hoomd.Snapshot.particles.types)
         They must be given in the same order as they form the angle
     start : int
@@ -47,21 +49,21 @@ def angle_distribution(
         if False, the angle values are returned in radians.
     histogram : bool, default=False
         If set to True, places the resulting angles into a histogram
-        and retrums the histogram's bin centers and heights as 
+        and retrums the histogram's bin centers and heights as
         opposed to the actual calcualted angles.
     theta_min : float, default = 0.0
         Sets the minimum theta value to be included in the distribution
-    theta_max : float, default = None 
+    theta_max : float, default = None
         Sets the maximum theta value to be included in the distribution
         If left as None, then theta_max will be either pi radians or
         180 degrees depending on the value set for the degrees parameter
     normalize : bool, default=False
         If set to True, normalizes the angle distribution by the
-        sum of the bin heights, so that the distribution adds up to 1. 
+        sum of the bin heights, so that the distribution adds up to 1.
     bins : float, int, or str,  default="auto"
         The number of bins to use when finding the distribution
         of bond angles. Using "auto" will set the number of
-        bins based on the ideal bin size for the data. 
+        bins based on the ideal bin size for the data.
         See the numpy.histogram docs for more details.
 
     Returns
@@ -81,7 +83,7 @@ def angle_distribution(
     name_rev = "-".join([C_name, B_name, A_name])
 
     angles = []
-    for snap in trajectory[start: stop]:
+    for snap in trajectory[start:stop]:
         if name not in snap.angles.types and name_rev not in snap.angles.types:
             raise ValueError(
                 f"Angles {name} or {name_rev} not found in "
@@ -110,16 +112,17 @@ def angle_distribution(
 
     if histogram:
         if min(angles) < theta_min or max(angles) > theta_max:
-            warnings.warn("There are bond angles that fall outside of "
-                          "your set theta_min and theta_max range. "
-                          "You may want to adjust this range to "
-                          "include all bond angles."
-                          )
+            warnings.warn(
+                "There are bond angles that fall outside of "
+                "your set theta_min and theta_max range. "
+                "You may want to adjust this range to "
+                "include all bond angles."
+            )
         bin_centers, bin_heights = get_histogram(
             data=np.array(angles),
             normalize=normalize,
             bins=bins,
-            x_range=(theta_min, theta_max)
+            x_range=(theta_min, theta_max),
         )
         return np.stack((bin_centers, bin_heights)).T
     else:
@@ -127,19 +130,19 @@ def angle_distribution(
 
 
 def bond_distribution(
-        gsd_file,
-        A_name,
-        B_name,
-        start=0,
-        stop=-1,
-        histogram=False,
-        l_min=0.0,
-        l_max=4.0,
-        normalize=True,
-        bins=100
+    gsd_file,
+    A_name,
+    B_name,
+    start=0,
+    stop=-1,
+    histogram=False,
+    l_min=0.0,
+    l_max=4.0,
+    normalize=True,
+    bins=100,
 ):
-    """Returns the bond length distribution for a given bond pair 
-    
+    """Returns the bond length distribution for a given bond pair
+
     Parameters
     ----------
     gsdfile : str
@@ -154,19 +157,19 @@ def bond_distribution(
         Final frame index for accumulating bond lengths. (default -1)
     histogram : bool, default=False
         If set to True, places the resulting bonds into a histogram
-        and retrums the histogram's bin centers and heights as 
+        and retrums the histogram's bin centers and heights as
         opposed to the actual calcualted bonds.
     l_min : float, default = 0.0
         Sets the minimum bond length to be included in the distribution
-    l_max : float, default = 5.0 
+    l_max : float, default = 5.0
         Sets the maximum bond length value to be included in the distribution
     normalize : bool, default=False
         If set to True, normalizes the angle distribution by the
-        sum of the bin heights, so that the distribution adds up to 1. 
+        sum of the bin heights, so that the distribution adds up to 1.
     bins : float, int, or str,  default="auto"
         The number of bins to use when finding the distribution
         of bond angles. Using "auto" will set the number of
-        bins based on the ideal bin size for the data. 
+        bins based on the ideal bin size for the data.
         See the numpy.histogram docs for more details.
 
     Returns
@@ -183,9 +186,10 @@ def bond_distribution(
     bonds = []
     for snap in trajectory[start:stop]:
         if name not in snap.bonds.types and name_rev not in snap.bonds.types:
-            raise ValueError(f"Bond types {name} or {name_rev} not found "
-                             "snap.bonds.types."
-                             )
+            raise ValueError(
+                f"Bond types {name} or {name_rev} not found "
+                "snap.bonds.types."
+            )
         for idx, bond in enumerate(snap.bonds.typeid):
             bond_name = snap.bonds.types[bond]
             if bond_name in [name, name_rev]:
@@ -202,15 +206,16 @@ def bond_distribution(
 
     if histogram:
         if min(bonds) < l_min or max(bonds) > l_max:
-            warnings.warn("There are bond lengths that fall outside of "
-                          "your set l_min and l_max range. You may want to adjust "
-                          "this range to include all bond lengths."
-                          )
+            warnings.warn(
+                "There are bond lengths that fall outside of "
+                "your set l_min and l_max range. You may want to adjust "
+                "this range to include all bond lengths."
+            )
         bin_centers, bin_heights = get_histogram(
             data=np.array(bonds),
             normalize=normalize,
             bins=bins,
-            x_range=(l_min, l_max)
+            x_range=(l_min, l_max),
         )
         return np.stack((bin_centers, bin_heights)).T
     else:
@@ -218,28 +223,28 @@ def bond_distribution(
 
 
 def dihedral_distribution(
-        gsd_file,
-        A_name,
-        B_name,
-        C_name,
-        D_name,
-        start=0,
-        stop=-1,
-        degrees=False,
-        histogram=False,
-        normalize=False,
-        bins="auto"
+    gsd_file,
+    A_name,
+    B_name,
+    C_name,
+    D_name,
+    start=0,
+    stop=-1,
+    degrees=False,
+    histogram=False,
+    normalize=False,
+    bins="auto",
 ):
-    """Returns the bond angle distribution for a given triplet of particles 
-    
+    """Returns the bond angle distribution for a given triplet of particles
+
     Parameters
     ----------
     gsdfile : str
         Filename of the GSD trajectory.
     A_name, B_name, C_name, D_name: str
-        Name(s) of particles that form the dihedral quadruplett 
+        Name(s) of particles that form the dihedral quadruplett
         (found in gsd.hoomd.Snapshot.particles.types)
-        They must be given in the same order as they form the dihedral 
+        They must be given in the same order as they form the dihedral
     start : int
         Starting frame index for accumulating bond lengths.
         Negative numbers index from the end. (default 0)
@@ -250,15 +255,15 @@ def dihedral_distribution(
         if False, the angle values are returned in radians.
     histogram : bool, default=False
         If set to True, places the resulting angles into a histogram
-        and retrums the histogram's bin centers and heights as 
+        and retrums the histogram's bin centers and heights as
         opposed to the actual calcualted angles.
     normalize : bool, default=False
         If set to True, normalizes the dihedral distribution by the
-        sum of the bin heights, so that the distribution adds up to 1. 
+        sum of the bin heights, so that the distribution adds up to 1.
     bins : float, int, or str,  default="auto"
         The number of bins to use when finding the distribution
         of bond angles. Using "auto" will set the number of
-        bins based on the ideal bin size for the data. 
+        bins based on the ideal bin size for the data.
         See the numpy.histogram docs for more details.
 
     Returns
@@ -273,9 +278,11 @@ def dihedral_distribution(
     name_rev = "-".join([D_name, C_name, B_name, A_name])
 
     dihedrals = []
-    for snap in trajectory[start: stop]:
-        if (name not in snap.dihedrals.types and
-                name_rev not in snap.dihedrals.types):
+    for snap in trajectory[start:stop]:
+        if (
+            name not in snap.dihedrals.types
+            and name_rev not in snap.dihedrals.types
+        ):
             raise ValueError(
                 f"Dihedrals {name} or {name_rev} not found in "
                 " snap.dihedrals.types. "
@@ -308,7 +315,7 @@ def dihedral_distribution(
             data=np.array(dihedrals),
             normalize=normalize,
             bins=bins,
-            x_range=(-np.pi, np.pi)
+            x_range=(-np.pi, np.pi),
         )
         return np.stack((bin_centers, bin_heights)).T
     else:
@@ -338,7 +345,7 @@ def get_quaternions(n_views=20):
     if n_views <= 3 or not isinstance(n_views, int):
         raise ValueError("Please set n_views to an integer greater than 3.")
     # Calculate points for even distribution on a sphere
-    ga = np.pi * (3 - 5 ** 0.5)
+    ga = np.pi * (3 - 5**0.5)
     theta = ga * np.arange(n_views - 3)
     z = np.linspace(1 - 1 / (n_views - 3), 1 / (n_views - 3), n_views - 3)
     radius = np.sqrt(1 - z * z)
@@ -359,15 +366,15 @@ def get_quaternions(n_views=20):
 
 
 def gsd_rdf(
-        gsdfile,
-        A_name,
-        B_name,
-        start=0,
-        stop=-1,
-        r_max=None,
-        r_min=0,
-        bins=100,
-        exclude_bonded=True,
+    gsdfile,
+    A_name,
+    B_name,
+    start=0,
+    stop=-1,
+    r_max=None,
+    r_min=0,
+    bins=100,
+    exclude_bonded=True,
 ):
     """Compute intermolecular RDF from a GSD file.
 
@@ -460,11 +467,13 @@ def gsd_rdf(
 
 
 def get_centers(gsdfile, new_gsdfile):
-    """Create a gsd file containing the molecule centers from an existing gsd file.
+    """Create a gsd file containing the molecule centers from an existing gsd
+     file.
 
 
     This function calculates the centers of a trajectory given a GSD file
-    and stores them into a new GSD file just for centers. By default it will calculate the centers of an entire trajectory.
+    and stores them into a new GSD file just for centers. By default it will
+    calculate the centers of an entire trajectory.
 
     Parameters
     ----------
@@ -473,8 +482,9 @@ def get_centers(gsdfile, new_gsdfile):
     new_gsdfile : str
         Filename of new GSD for centers.
     """
-    with gsd.hoomd.open(new_gsdfile, 'wb') as new_traj, gsd.hoomd.open(gsdfile,
-                                                                       'rb') as traj:
+    with gsd.hoomd.open(new_gsdfile, "wb") as new_traj, gsd.hoomd.open(
+        gsdfile, "rb"
+    ) as traj:
         snap = traj[0]
         cluster_idx = gsd_utils.get_molecule_cluster(snap=snap)
         for snap in traj:
@@ -482,8 +492,9 @@ def get_centers(gsdfile, new_gsdfile):
             new_snap.configuration.box = snap.configuration.box
             f_box = freud.box.Box.from_box(snap.configuration.box)
             # Use the freud box to unwrap the particle positions
-            unwrapped_positions = f_box.unwrap(snap.particles.position,
-                                               snap.particles.image)
+            unwrapped_positions = f_box.unwrap(
+                snap.particles.position, snap.particles.image
+            )
             uw_centers = []
             for i in range(max(cluster_idx) + 1):
                 cluster_uw_pos = unwrapped_positions[np.where(cluster_idx == i)]
@@ -566,7 +577,7 @@ def order_parameter(aa_gsd, cg_gsd, mapping, r_max, a_max, large=6, start=-10):
             aq = freud.locality.AABBQuery.from_system(cg_snap)
             n_list = aq.query(
                 cg_snap.particles.position,
-                query_args={"exclude_ii": True, "r_max": r_max}
+                query_args={"exclude_ii": True, "r_max": r_max},
             ).toNeighborList()
 
             vec_point = [
@@ -577,10 +588,12 @@ def order_parameter(aa_gsd, cg_gsd, mapping, r_max, a_max, large=6, start=-10):
                 get_plane_normal(unwrap_xyz[mapping[i]])[1]
                 for i in n_list.query_point_indices
             ]
-            n_list.filter([
-                angle_between_vectors(i, j) < a_max
-                for i, j in zip(vec_point, vec_querypoint)
-            ])
+            n_list.filter(
+                [
+                    angle_between_vectors(i, j) < a_max
+                    for i, j in zip(vec_point, vec_querypoint)
+                ]
+            )
             cl = freud.cluster.Cluster()
             cl.compute(cg_snap, neighbors=n_list)
             n_large = sum([len(i) for i in cl.cluster_keys if len(i) >= large])
@@ -590,13 +603,14 @@ def order_parameter(aa_gsd, cg_gsd, mapping, r_max, a_max, large=6, start=-10):
     return order, cl_idx
 
 
-def all_atom_rdf(gsdfile,
-                 start=0,
-                 stop=-1,
-                 r_max=None,
-                 r_min=0,
-                 bins=100,
-                 ):
+def all_atom_rdf(
+    gsdfile,
+    start=0,
+    stop=-1,
+    r_max=None,
+    r_min=0,
+    bins=100,
+):
     """Compute intermolecular RDF from a GSD file.
 
     This function calculates the radial distribution function given a GSD file

--- a/cmeutils/tests/base_test.py
+++ b/cmeutils/tests/base_test.py
@@ -1,11 +1,9 @@
 from os import path
-import pytest
-import tempfile
 
 import gsd.hoomd
 import numpy as np
+import pytest
 from pymbar.testsystems import correlated_timeseries_example
-
 
 asset_dir = path.join(path.dirname(__file__), "assets")
 
@@ -81,9 +79,9 @@ def create_frame(i, add_bonds, images, seed=42):
         s.bonds.typeid = [0, 0, 1]
         s.bonds.group = [[0, 2], [1, 3], [3, 4]]
     if images:
-        s.particles.image = np.full(shape=(5,3), fill_value=i)
+        s.particles.image = np.full(shape=(5, 3), fill_value=i)
     else:
-        s.particles.image = np.zeros(shape=(5,3))
+        s.particles.image = np.zeros(shape=(5, 3))
     s.validate()
     return s
 

--- a/cmeutils/tests/test_dynamics.py
+++ b/cmeutils/tests/test_dynamics.py
@@ -1,13 +1,17 @@
 import pytest
 
-from cmeutils.tests.base_test import BaseTest
 from cmeutils.dynamics import msd_from_gsd
+from cmeutils.tests.base_test import BaseTest
+
 
 class TestDynamics(BaseTest):
     def test_gsd_msd(self, gsdfile_images):
         msd_window = msd_from_gsd(gsdfile_images)
         msd_direct = msd_from_gsd(gsdfile_images, msd_mode="direct")
+        assert msd_window is not None
+        assert msd_direct is not None
 
     def test_gsd_no_images(self, gsdfile):
         with pytest.warns(UserWarning):
             msd = msd_from_gsd(gsdfile)
+        assert msd is not None

--- a/cmeutils/tests/test_geometry.py
+++ b/cmeutils/tests/test_geometry.py
@@ -2,25 +2,24 @@ import math
 
 import numpy as np
 import pytest
-
 from base_test import BaseTest
-from cmeutils.geometry import get_plane_normal, angle_between_vectors, moit, \
-    radial_grid_positions, \
-    spherical_grid_positions
+
+from cmeutils.geometry import (
+    angle_between_vectors,
+    get_plane_normal,
+    moit,
+    radial_grid_positions,
+    spherical_grid_positions,
+)
 
 
 class TestGeometry(BaseTest):
     def test_moit(self):
         _moit = moit(points=[(-1, 0, 0), (1, 0, 0)], masses=[1, 1])
-        assert np.array_equal(_moit, np.array([0, 2., 2.]))
+        assert np.array_equal(_moit, np.array([0, 2.0, 2.0]))
 
     def test_get_plane_normal(self):
-        points = np.array(
-            [[1, 0, 0],
-             [0, 1, 0],
-             [-1, 0, 0],
-             [0, -1, 0]]
-        )
+        points = np.array([[1, 0, 0], [0, 1, 0], [-1, 0, 0], [0, -1, 0]])
         ctr, norm = get_plane_normal(points)
         assert np.allclose(ctr, np.array([0, 0, 0]))
         assert np.allclose(norm, np.array([0, 0, 1]))
@@ -41,13 +40,13 @@ class TestGeometry(BaseTest):
             math.pi / 2,
             angle_between_vectors(
                 np.array([1, 0, 0]), np.array([0, 1, 0]), degrees=False
-            )
+            ),
         )
         assert np.isclose(
             0,
             angle_between_vectors(
                 np.array([1, 0, 0]), np.array([-1, 0, 0]), degrees=False
-            )
+            ),
         )
 
     def test_radial_grid_positions(self):
@@ -57,11 +56,10 @@ class TestGeometry(BaseTest):
             init_position=np.zeros(2),
             n_circles=2,
             circle_slice=2,
-            circle_coverage=np.pi
+            circle_coverage=np.pi,
         )
         assert np.array_equal(
-            grid,
-            np.array([[1., 0.], [-1., 0.], [2., 0], [-2, 0]])
+            grid, np.array([[1.0, 0.0], [-1.0, 0.0], [2.0, 0], [-2, 0]])
         )
 
     def test_radial_grid_positions_quarter_circle(self):
@@ -71,20 +69,22 @@ class TestGeometry(BaseTest):
             init_position=np.zeros(2),
             n_circles=2,
             circle_slice=4,
-            circle_coverage=np.pi / 2
+            circle_coverage=np.pi / 2,
         )
         assert np.array_equal(
             grid,
-            np.array([
-                [1., 0.],
-                [0.866, 0.5],
-                [0.5, 0.866],
-                [0., 1.],
-                [2., 0.],
-                [1.732, 1.],
-                [1., 1.732],
-                [0., 2.]
-            ])
+            np.array(
+                [
+                    [1.0, 0.0],
+                    [0.866, 0.5],
+                    [0.5, 0.866],
+                    [0.0, 1.0],
+                    [2.0, 0.0],
+                    [1.732, 1.0],
+                    [1.0, 1.732],
+                    [0.0, 2.0],
+                ]
+            ),
         )
 
     def test_radial_grid_positions_along_x(self):
@@ -94,11 +94,10 @@ class TestGeometry(BaseTest):
             init_position=np.zeros(2),
             n_circles=3,
             circle_slice=1,
-            circle_coverage=np.pi * 2
+            circle_coverage=np.pi * 2,
         )
         assert np.array_equal(
-            grid,
-            np.array([[1., 0.], [2., 0.], [3., 0.]])
+            grid, np.array([[1.0, 0.0], [2.0, 0.0], [3.0, 0.0]])
         )
 
     def test_radial_grid_positions_init_position(self):
@@ -108,16 +107,10 @@ class TestGeometry(BaseTest):
             init_position=np.array([1, 1]),
             n_circles=2,
             circle_slice=2,
-            circle_coverage=np.pi
+            circle_coverage=np.pi,
         )
         assert np.array_equal(
-            grid,
-            np.array([
-                [2., 1.],
-                [0., 1.],
-                [3., 1.],
-                [-1., 1.]
-            ])
+            grid, np.array([[2.0, 1.0], [0.0, 1.0], [3.0, 1.0], [-1.0, 1.0]])
         )
 
     def test_spherical_grid_positions(self):
@@ -128,24 +121,26 @@ class TestGeometry(BaseTest):
             n_circles=2,
             circle_slice=2,
             circle_coverage=np.pi,
-            z_coverage=np.pi
+            z_coverage=np.pi,
         )
         assert np.array_equal(
             grid,
-            np.array([
-                [0., 0., 1.],
-                [0.866, 0., 0.5],
-                [0.866, 0., -0.5],
-                [0., 0., -1.],
-                [-0.866, 0., 0.5],
-                [-0.866, 0., -0.5],
-                [0., 0., 2.],
-                [1.732, 0., 1.0],
-                [1.732, 0., -1.],
-                [0., 0., -2.],
-                [-1.732, 0., 1.],
-                [-1.732, 0., -1.]
-            ])
+            np.array(
+                [
+                    [0.0, 0.0, 1.0],
+                    [0.866, 0.0, 0.5],
+                    [0.866, 0.0, -0.5],
+                    [0.0, 0.0, -1.0],
+                    [-0.866, 0.0, 0.5],
+                    [-0.866, 0.0, -0.5],
+                    [0.0, 0.0, 2.0],
+                    [1.732, 0.0, 1.0],
+                    [1.732, 0.0, -1.0],
+                    [0.0, 0.0, -2.0],
+                    [-1.732, 0.0, 1.0],
+                    [-1.732, 0.0, -1.0],
+                ]
+            ),
         )
 
     def test_spherical_grid_positions_half_circle(self):
@@ -156,17 +151,19 @@ class TestGeometry(BaseTest):
             n_circles=2,
             circle_slice=2,
             circle_coverage=np.pi,
-            z_coverage=np.pi / 2
+            z_coverage=np.pi / 2,
         )
         assert np.array_equal(
             grid,
-            np.array([
-                [0., 0., 1.],
-                [0.5, 0, 0.866],
-                [0.866, 0., 0.5],
-                [1, 0., 0.],
-                [-0.5, 0, 0.866],
-                [-0.866, 0., 0.5],
-                [-1., 0., 0.]
-            ])
+            np.array(
+                [
+                    [0.0, 0.0, 1.0],
+                    [0.5, 0, 0.866],
+                    [0.866, 0.0, 0.5],
+                    [1, 0.0, 0.0],
+                    [-0.5, 0, 0.866],
+                    [-0.866, 0.0, 0.5],
+                    [-1.0, 0.0, 0.0],
+                ]
+            ),
         )

--- a/cmeutils/tests/test_imports.py
+++ b/cmeutils/tests/test_imports.py
@@ -1,3 +1,8 @@
+# ignoring unused imports for testing purposes
+# flake8: noqa: F401
 def test_import():
-    import cmeutils
-    from cmeutils import gsd_utils
+    try:
+        import cmeutils
+        from cmeutils import gsd_utils
+    except ImportError:
+        assert False

--- a/cmeutils/tests/test_plotting.py
+++ b/cmeutils/tests/test_plotting.py
@@ -1,10 +1,7 @@
 import numpy as np
-import pytest
-
-from cmeutils.plotting import get_histogram
-from cmeutils.plotting import threedplot
-
 from base_test import BaseTest
+
+from cmeutils.plotting import get_histogram, threedplot
 
 
 class TestPlotting(BaseTest):
@@ -14,13 +11,12 @@ class TestPlotting(BaseTest):
         assert len(bin_c) == len(bin_h) == 20
 
     def test_histogram_normalize(self):
-        sample = np.random.randn(100)*-1
+        sample = np.random.randn(100) * -1
         bin_c, bin_h = get_histogram(sample, normalize=True)
         assert all(bin_h <= 1)
 
     def test_3dplot(self):
-        x = [1,2,3,4,5]
-        y = [1,2,3,4,5]
-        z = [1,2,3,4,5]
-        threedplot(x,y,z)
-
+        x = [1, 2, 3, 4, 5]
+        y = [1, 2, 3, 4, 5]
+        z = [1, 2, 3, 4, 5]
+        threedplot(x, y, z)

--- a/cmeutils/tests/test_sampling.py
+++ b/cmeutils/tests/test_sampling.py
@@ -1,10 +1,9 @@
 import numpy as np
 import pytest
-from pymbar import testsystems
-from pymbar.testsystems.timeseries import correlated_timeseries_example
 
-from cmeutils.tests.base_test import BaseTest
 from cmeutils.sampling import equil_sample, is_equilibrated
+from cmeutils.tests.base_test import BaseTest
+
 
 class TestSampler(BaseTest):
     def test_is_equilibrated(self, correlated_data_tau100_n10000):
@@ -70,7 +69,9 @@ class TestSampler(BaseTest):
 
     def test_trim_high_threshold(self, correlated_data_tau100_n10000):
         data = correlated_data_tau100_n10000
-        with pytest.raises(ValueError, match=r"Property does not have requisite threshold"):
+        with pytest.raises(
+            ValueError, match=r"Property does not have requisite threshold"
+        ):
             [equil_data, uncorr_indices, prod_start, Neff] = equil_sample(
                 data, threshold_fraction=0.98
             )

--- a/cmeutils/tests/test_structure.py
+++ b/cmeutils/tests/test_structure.py
@@ -1,51 +1,47 @@
 import math
+
+import freud
+import numpy as np
 import pytest
 
-import gsd
-
-import numpy as np
-import freud
-
+from cmeutils.structure import (
+    all_atom_rdf,
+    angle_distribution,
+    bond_distribution,
+    dihedral_distribution,
+    get_centers,
+    get_quaternions,
+    gsd_rdf,
+    order_parameter,
+)
 from cmeutils.tests.base_test import BaseTest
 
-from cmeutils.structure import (
-        angle_distribution,
-        bond_distribution,
-        dihedral_distribution,
-        gsd_rdf,
-        get_quaternions, 
-        order_parameter,
-        all_atom_rdf,
-        get_centers
-    )
 
 class TestStructure(BaseTest):
     def test_dihedral_distribution_deg(self, butane_gsd):
         dihedrals = dihedral_distribution(
-                butane_gsd, "c3", "c3", "c3", "c3", start=0, stop=1, degrees=True
+            butane_gsd, "c3", "c3", "c3", "c3", start=0, stop=1, degrees=True
         )
         for phi in dihedrals:
             assert -180 <= phi <= 180
 
     def test_dihedral_distribution_rad(self, butane_gsd):
         dihedrals = dihedral_distribution(
-                butane_gsd, "c3", "c3", "c3", "c3", degrees=False
+            butane_gsd, "c3", "c3", "c3", "c3", degrees=False
         )
         for phi in dihedrals:
-            assert -math.pi <= phi <= math.pi 
+            assert -math.pi <= phi <= math.pi
 
     def test_dihedral_distribution_not_found(self, butane_gsd):
         with pytest.raises(ValueError):
-            dihedrals = dihedral_distribution(
-                    butane_gsd, "c3", "c3", "c3", "c"
-            )
+            dihedral_distribution(butane_gsd, "c3", "c3", "c3", "c")
 
     def test_dihedral_distribution_histogram(self, butane_gsd):
         dihedrals = dihedral_distribution(
-                butane_gsd, "c3", "c3", "c3", "c3", histogram=True
+            butane_gsd, "c3", "c3", "c3", "c3", histogram=True
         )
         for phi in dihedrals[:, 0]:
-            assert -math.pi <= phi <= math.pi 
+            assert -math.pi <= phi <= math.pi
 
     def test_angle_distribution_deg(self, p3ht_gsd):
         angles = angle_distribution(p3ht_gsd, "cc", "ss", "cc", degrees=True)
@@ -54,35 +50,39 @@ class TestStructure(BaseTest):
 
     def test_angle_distribution_range(self, p3ht_gsd):
         angles = angle_distribution(
-                p3ht_gsd,
-                "cc",
-                "ss",
-                "cc",
-                start=0,
-                stop=1,
-                histogram=True,
-                degrees=True,
-                theta_min=10,
-                theta_max=180
+            p3ht_gsd,
+            "cc",
+            "ss",
+            "cc",
+            start=0,
+            stop=1,
+            histogram=True,
+            degrees=True,
+            theta_min=10,
+            theta_max=180,
         )
-        assert np.allclose(angles[0,0],10, atol=0.5)
-        assert np.allclose(angles[-1,0], 180, atol=0.5)
+        assert np.allclose(angles[0, 0], 10, atol=0.5)
+        assert np.allclose(angles[-1, 0], 180, atol=0.5)
 
     def test_angle_distribution_rad(self, p3ht_gsd):
-        angles = angle_distribution(p3ht_gsd, "cc", "ss", "cc", start=0, stop=1, degrees=False)
+        angles = angle_distribution(
+            p3ht_gsd, "cc", "ss", "cc", start=0, stop=1, degrees=False
+        )
         for ang in angles:
             assert 1.40 < ang < 1.75
 
     def test_angle_distribution_order(self, p3ht_gsd):
         angles = angle_distribution(p3ht_gsd, "ss", "cc", "cd", start=0, stop=1)
-        angles2 = angle_distribution(p3ht_gsd, "cd", "cc", "ss", start=0, stop=1)
+        angles2 = angle_distribution(
+            p3ht_gsd, "cd", "cc", "ss", start=0, stop=1
+        )
         assert angles.shape[0] > 0
         assert angles.shape == angles2.shape
         assert np.array_equal(angles, angles2)
 
     def test_angle_not_found(self, p3ht_gsd):
         with pytest.raises(ValueError):
-            angles = angle_distribution(p3ht_gsd, "cc", "xx", "cc", start=0, stop=1)
+            angle_distribution(p3ht_gsd, "cc", "xx", "cc", start=0, stop=1)
 
     def test_bond_distribution(self, p3ht_gsd):
         bonds = bond_distribution(p3ht_gsd, "cc", "ss", start=0, stop=1)
@@ -92,17 +92,17 @@ class TestStructure(BaseTest):
 
     def test_bond_distribution_range(self, p3ht_gsd):
         bonds = bond_distribution(
-                p3ht_gsd,
-                "cc",
-                "ss",
-                start=0,
-                stop=1,
-                l_min=0,
-                l_max=1,
-                histogram=True
+            p3ht_gsd,
+            "cc",
+            "ss",
+            start=0,
+            stop=1,
+            l_min=0,
+            l_max=1,
+            histogram=True,
         )
-        assert np.allclose(bonds[0,0],0, atol=0.5)
-        assert np.allclose(bonds[-1,0], 1, atol=0.5)
+        assert np.allclose(bonds[0, 0], 0, atol=0.5)
+        assert np.allclose(bonds[-1, 0], 1, atol=0.5)
 
     def test_bond_distribution_order(self, p3ht_gsd):
         bonds = bond_distribution(p3ht_gsd, "cc", "ss", start=0, stop=1)
@@ -112,33 +112,33 @@ class TestStructure(BaseTest):
 
     def test_bond_not_found(self, p3ht_gsd):
         with pytest.raises(ValueError):
-            bonds = bond_distribution(p3ht_gsd, "xx", "ss", start=0, stop=1)
+            bond_distribution(p3ht_gsd, "xx", "ss", start=0, stop=1)
 
     def test_bond_histogram(self, p3ht_gsd):
         bonds_hist = bond_distribution(
-                p3ht_gsd, "cc", "ss", start=0, stop=1, histogram=True
+            p3ht_gsd, "cc", "ss", start=0, stop=1, histogram=True
         )
         bonds_no_hist = bond_distribution(
-                p3ht_gsd, "cc", "ss", start=0, stop=1, histogram=False
+            p3ht_gsd, "cc", "ss", start=0, stop=1, histogram=False
         )
         assert bonds_hist.ndim == 2
         assert bonds_no_hist.ndim == 1
 
     def test_bond_dist_normalize(self, p3ht_gsd):
         bonds_hist = bond_distribution(
-                p3ht_gsd,
-                "cc",
-                "ss",
-                start=0,
-                stop=1,
-                histogram=True,
-                normalize=True
+            p3ht_gsd,
+            "cc",
+            "ss",
+            start=0,
+            stop=1,
+            histogram=True,
+            normalize=True,
         )
-        assert np.allclose(np.sum(bonds_hist[:,1]), 1, 1e-3)
+        assert np.allclose(np.sum(bonds_hist[:, 1]), 1, 1e-3)
 
     def test_bond_range_outside(self, p3ht_gsd):
         with pytest.warns(UserWarning):
-            bonds_hist = bond_distribution(
+            bond_distribution(
                 p3ht_gsd,
                 "cc",
                 "ss",
@@ -146,21 +146,35 @@ class TestStructure(BaseTest):
                 stop=1,
                 histogram=True,
                 l_min=0.52,
-                l_max=0.60
+                l_max=0.60,
             )
 
     def test_angle_histogram(self, p3ht_gsd):
         angles_hist = angle_distribution(
-                p3ht_gsd, "cc", "ss", "cc", start=0, stop=1, histogram=True
+            p3ht_gsd, "cc", "ss", "cc", start=0, stop=1, histogram=True
         )
         angles_no_hist = angle_distribution(
-                p3ht_gsd, "cc", "ss", "cc", start=0, stop=1, histogram=False
+            p3ht_gsd, "cc", "ss", "cc", start=0, stop=1, histogram=False
         )
         assert angles_hist.ndim == 2
         assert angles_no_hist.ndim == 1
 
     def test_angle_dist_normalize(self, p3ht_gsd):
         angles_hist = angle_distribution(
+            p3ht_gsd,
+            "cc",
+            "ss",
+            "cc",
+            start=0,
+            stop=1,
+            histogram=True,
+            normalize=True,
+        )
+        assert np.allclose(np.sum(angles_hist[:, 1]), 1, 1e-3)
+
+    def test_angle_range_outside(self, p3ht_gsd):
+        with pytest.warns(UserWarning):
+            angle_distribution(
                 p3ht_gsd,
                 "cc",
                 "ss",
@@ -168,28 +182,14 @@ class TestStructure(BaseTest):
                 start=0,
                 stop=1,
                 histogram=True,
-                normalize=True,
-        )
-        assert np.allclose(np.sum(angles_hist[:,1]), 1, 1e-3)
-    
-    def test_angle_range_outside(self, p3ht_gsd):
-        with pytest.warns(UserWarning):
-            angles_hist = angle_distribution(
-                    p3ht_gsd,
-                    "cc",
-                    "ss",
-                    "cc",
-                    start=0,
-                    stop=1,
-                    histogram=True,
-                    theta_min = 120,
-                    theta_max=180
+                theta_min=120,
+                theta_max=180,
             )
 
     def test_gsd_rdf(self, gsdfile_bond):
         rdf_ex, norm = gsd_rdf(gsdfile_bond, "A", "B")
         rdf_noex, norm2 = gsd_rdf(gsdfile_bond, "A", "B", exclude_bonded=False)
-        assert np.isclose(norm2, 2/3, 1e-4)
+        assert np.isclose(norm2, 2 / 3, 1e-4)
         assert not np.array_equal(rdf_noex, rdf_ex)
 
     def test_gsd_rdf_samename(self, gsdfile_bond):
@@ -200,12 +200,12 @@ class TestStructure(BaseTest):
 
     def test_gsd_rdf_pair_order(self, gsdfile_bond):
         rdf, norm = gsd_rdf(gsdfile_bond, "A", "B")
-        rdf_y = rdf.rdf*norm
+        rdf_y = rdf.rdf * norm
         rdf2, norm2 = gsd_rdf(gsdfile_bond, "B", "A")
-        rdf_y2 = rdf2.rdf*norm2
+        rdf_y2 = rdf2.rdf * norm2
 
-        for i,j in zip(rdf_y, rdf_y2):
-            assert np.allclose(i,j,atol=1e-4)
+        for i, j in zip(rdf_y, rdf_y2):
+            assert np.allclose(i, j, atol=1e-4)
 
     def test_get_quaternions(self):
         with pytest.raises(ValueError):
@@ -232,8 +232,8 @@ class TestStructure(BaseTest):
     def test_all_atom_rdf(self, gsdfile):
         rdf = all_atom_rdf(gsdfile)
         assert isinstance(rdf, freud.density.RDF)
-        
+
     def test_get_centers(self, gsdfile):
         new_gsdfile = "centers.gsd"
-        centers = get_centers(gsdfile, new_gsdfile) 
+        centers = get_centers(gsdfile, new_gsdfile)
         assert isinstance(centers, type(None))

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,4 +10,3 @@ ignore:
     - "cmeutils/tests"
     - "cmeutils/__version__.py"
     - "setup.py"
-

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,4 +1,4 @@
-name: cmeutils
+name: cmeutils-dev
 channels:
   - conda-forge
 dependencies:
@@ -10,5 +10,8 @@ dependencies:
   - pip
   - python
   - matplotlib
+  - pre-commit
   - pymbar >= 4.0
+  - pytest
+  - pytest-cov
   - rowan

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import os
-from setuptools import setup, find_packages
 
+from setuptools import find_packages, setup
 
 NAME = "cmeutils"
 here = os.path.abspath(os.path.dirname(__file__))
@@ -8,14 +8,15 @@ about = {}
 with open(os.path.join(here, NAME, "__version__.py")) as f:
     exec(f.read(), about)
 
-setup(name=NAME,
-      version=about["__version__"],
-      description='Helpful functions used in the CME lab',
-      url='https://github.com/cmelab/cmeutils',
-      author='CME Lab',
-      author_email='ericjankowski@boisestate.edu',
-      license='GPLv3',
-      packages=find_packages(),
-      package_dir={'cmeutils': 'cmeutils'},
-      zip_safe=False,
-      )
+setup(
+    name=NAME,
+    version=about["__version__"],
+    description="Helpful functions used in the CME lab",
+    url="https://github.com/cmelab/cmeutils",
+    author="CME Lab",
+    author_email="ericjankowski@boisestate.edu",
+    license="GPLv3",
+    packages=find_packages(),
+    package_dir={"cmeutils": "cmeutils"},
+    zip_safe=False,
+)


### PR DESCRIPTION
This PR add pre-commit hooks to the repository, which helps with keeping the code clean and avoids formatting confusions.

I added the following hooks which are pretty common:

- `pre-commit-hooks`

    - `check-yaml`: checks yaml files for parseable syntax.
    - `end-of-file-fixer`: ensures that a file is either empty, or ends with one newline.
    - `trailing-whitespace`: trims trailing whitespace.
    - Line length is set to 80 for all files.

- `isort`: sorts imports alphabetically and automatically separates into sections and by type. 

- `flake8`: for style guide enforcement.
    -  note: flake8 errors can be annoying sometimes, but I think it's better to keep it as it makes the code cleaner.
    - When necessary, we can easily [ignore flake8 errors ](https://flake8.pycqa.org/en/3.1.1/user/ignoring-errors.html)for a specific line or file.


There is also `pydocstyle` hook for checking compliance with Python docstring conventions, which I commented for now. Lots of docstring formatting needs to be done, which takes a lot of time honestly :D I will do it slowly over time.