### PR TITLE
Fix camera position buffer factor

### DIFF
--- a/cmeutils/tests/test_visualize.py
+++ b/cmeutils/tests/test_visualize.py
@@ -134,8 +134,12 @@ class TestFresnelGSD(BaseTest):
         assert p3ht_fresnel.box_radius == 0.1
 
     def test_default_height(self, p3ht_fresnel):
-        assert p3ht_fresnel.height == np.linalg.norm(
-            p3ht_fresnel.box_length[:3] * p3ht_fresnel.view_axis
+        assert (
+            p3ht_fresnel.height
+            == np.linalg.norm(
+                p3ht_fresnel.box_length[:3] * p3ht_fresnel.view_axis
+            )
+            * p3ht_fresnel._height_factor
         )
 
     def test_reset_height(self, p3ht_fresnel):

--- a/cmeutils/visualize.py
+++ b/cmeutils/visualize.py
@@ -75,6 +75,7 @@ class FresnelGSD:
         self.gsd_file = gsd_file
         with gsd.hoomd.open(gsd_file) as traj:
             self._n_frames = len(traj)
+        self._height_factor = 1.25
         self._unwrap_positions = unwrap_positions
         self._snapshot = None
         self._view_axis = np.asarray(view_axis)
@@ -92,7 +93,6 @@ class FresnelGSD:
         self._up = np.asarray(up)
         self._show_box = show_box
         self._box_radius = box_radius
-        self._height_factor = 1.25
 
     @property
     def frame(self):
@@ -321,7 +321,8 @@ class FresnelGSD:
 
     def _default_height(self):
         """Set the height based on box dimensions and view axis"""
-        return np.linalg.norm(self.view_axis * self.box_length[:3])
+        height = np.linalg.norm(self.view_axis * self.box_length[:3])
+        return height * self._height_factor
 
     def reset_height(self):
         """Reset the height of the camera to the default."""
@@ -379,7 +380,7 @@ class FresnelGSD:
             position=self.camera_position,
             look_at=self.look_at,
             up=self.up,
-            height=self.height * self._height_factor,
+            height=self.height,
         )
         return camera
 

--- a/cmeutils/visualize.py
+++ b/cmeutils/visualize.py
@@ -264,7 +264,7 @@ class FresnelGSD:
     def camera_position(self):
         """The camera position.
         Determined from box dimensions are FresnelGSD.view_axis"""
-        return (self.snapshot.configuration.box[:3] * self.view_axis) - 0.5
+        return (self.snapshot.configuration.box[:3] * self.view_axis) * 0.95
 
     @property
     def look_at(self):

--- a/cmeutils/visualize.py
+++ b/cmeutils/visualize.py
@@ -89,10 +89,10 @@ class FresnelGSD:
         self._specular = specular
         self._specular_trans = specular_trans
         self._metal = metal
-        # self._view_axis = np.asarray(view_axis)
         self._up = np.asarray(up)
         self._show_box = show_box
         self._box_radius = box_radius
+        self._height_factor = 1.25
 
     @property
     def frame(self):
@@ -379,7 +379,7 @@ class FresnelGSD:
             position=self.camera_position,
             look_at=self.look_at,
             up=self.up,
-            height=self.height,
+            height=self.height * self._height_factor,
         )
         return camera
 

--- a/cmeutils/visualize.py
+++ b/cmeutils/visualize.py
@@ -263,8 +263,8 @@ class FresnelGSD:
     @property
     def camera_position(self):
         """The camera position.
-        Determined from box dimensions are FresnelGSD.view_axis"""
-        return (self.snapshot.configuration.box[:3] * self.view_axis) * 0.95
+        Determined from box dimensions and FresnelGSD.view_axis"""
+        return self.snapshot.configuration.box[:3] * self.view_axis
 
     @property
     def look_at(self):


### PR DESCRIPTION
The camera position was slightly skewed because I was subtracting 0.5 from all coordinates. This PR changes this to use a multiplication factor to slightly adjust the camera position outward.