### PR TITLE
Add setter for colors property

### DIFF
--- a/cmeutils/tests/test_visualize.py
+++ b/cmeutils/tests/test_visualize.py
@@ -76,6 +76,11 @@ class TestFresnelGSD(BaseTest):
         with pytest.raises(ValueError):
             p3ht_fresnel.unwrap_positions = "true"
 
+    def set_set_colors(self, p3ht_fresnel):
+        colors = np.zeros_like(p3ht_fresnel.positions)
+        colors[:] = np.array([0.5, 0.5, 0.5])
+        p3ht_fresnel.colors = colors
+
     def test_unwrap_positions(self, p3ht_fresnel):
         assert p3ht_fresnel.unwrap_positions is False
         p3ht_fresnel.unwrap_positions = True

--- a/cmeutils/tests/test_visualize.py
+++ b/cmeutils/tests/test_visualize.py
@@ -45,6 +45,17 @@ class TestFresnelGSD(BaseTest):
         )
         p3ht_fresnel.view()
 
+    def test_camera_position(self, p3ht_fresnel):
+        init_pos = p3ht_fresnel.camera_position
+        p3ht_fresnel.view_axis = (1, 1, 0)
+        assert not all(np.not_equal(init_pos, p3ht_fresnel.camera_position))
+        box = p3ht_fresnel.snapshot.configuration.box[:3]
+        assert np.array_equal(
+            p3ht_fresnel.camera_position, box * np.array([1, 1, 0])
+        )
+        camera = p3ht_fresnel.camera()
+        assert np.array_equal(camera.position, box * np.array([1, 1, 0]))
+
     def test_set_color_no_type(self, p3ht_fresnel):
         with pytest.raises(ValueError):
             p3ht_fresnel.set_type_color("ca", (0.1, 0.1, 0.1))

--- a/cmeutils/tests/test_visualize.py
+++ b/cmeutils/tests/test_visualize.py
@@ -134,8 +134,12 @@ class TestFresnelGSD(BaseTest):
         assert p3ht_fresnel.box_radius == 0.1
 
     def test_default_height(self, p3ht_fresnel):
-        assert p3ht_fresnel.height == np.linalg.norm(
-            p3ht_fresnel.box_length[:3] * p3ht_fresnel.view_axis
+        assert (
+            p3ht_fresnel.height
+            == np.linalg.norm(
+                p3ht_fresnel.box_length[:3] * p3ht_fresnel.view_axis
+            )
+            * p3ht_fresnel._height_factor
         )
 
     def test_reset_height(self, p3ht_fresnel):

--- a/cmeutils/tests/test_visualize.py
+++ b/cmeutils/tests/test_visualize.py
@@ -80,6 +80,7 @@ class TestFresnelGSD(BaseTest):
         colors = np.zeros_like(p3ht_fresnel.positions)
         colors[:] = np.array([0.5, 0.5, 0.5])
         p3ht_fresnel.colors = colors
+        assert all(np.array_equal(colors, p3ht_fresnel.colors))
 
     def test_unwrap_positions(self, p3ht_fresnel):
         assert p3ht_fresnel.unwrap_positions is False

--- a/cmeutils/visualize.py
+++ b/cmeutils/visualize.py
@@ -82,6 +82,7 @@ class FresnelGSD:
         self._frame = 0
         self.frame = frame
         self._color_dict = color_dict
+        self._colors = None
         self._diameter_scale = diameter_scale
         self._height = height
         self._device = device
@@ -311,8 +312,14 @@ class FresnelGSD:
         """
         if self.color_dict:
             return np.array([self.color_dict[i] for i in self.particle_types])
-        else:
+        elif self._colors is None:
             return np.array([0.5, 0.25, 0.5])
+        else:
+            return self._colors
+
+    @colors.setter
+    def colors(self, value):
+        self._colors = value
 
     @property
     def box_length(self):

--- a/cmeutils/visualize.py
+++ b/cmeutils/visualize.py
@@ -82,7 +82,7 @@ class FresnelGSD:
         self._frame = 0
         self.frame = frame
         self._color_dict = color_dict
-        self._colors = None
+        self._colors = np.array([0.5, 0.25, 0.5])
         self._diameter_scale = diameter_scale
         self._height = height
         self._device = device
@@ -312,8 +312,6 @@ class FresnelGSD:
         """
         if self.color_dict:
             return np.array([self.color_dict[i] for i in self.particle_types])
-        elif self._colors is None:
-            return np.array([0.5, 0.25, 0.5])
         else:
             return self._colors
 

--- a/cmeutils/visualize.py
+++ b/cmeutils/visualize.py
@@ -75,6 +75,7 @@ class FresnelGSD:
         self.gsd_file = gsd_file
         with gsd.hoomd.open(gsd_file) as traj:
             self._n_frames = len(traj)
+        self._height_factor = 1.25
         self._unwrap_positions = unwrap_positions
         self._snapshot = None
         self._view_axis = np.asarray(view_axis)
@@ -92,7 +93,6 @@ class FresnelGSD:
         self._up = np.asarray(up)
         self._show_box = show_box
         self._box_radius = box_radius
-        self._height_factor = 1.25
 
     @property
     def frame(self):
@@ -321,7 +321,8 @@ class FresnelGSD:
 
     def _default_height(self):
         """Set the height based on box dimensions and view axis"""
-        return np.linalg.norm(self.view_axis * self.box_length[:3])
+        height = np.linalg.norm(self.view_axis * self.box_length[:3])
+        return height * self._height_factor
 
     def reset_height(self):
         """Reset the height of the camera to the default."""
@@ -379,7 +380,7 @@ class FresnelGSD:
             position=self.camera_position,
             look_at=self.look_at,
             up=self.up,
-            height=self.height * self._height_factor,
+            height=self.height,
         )
         return camera
 

--- a/cmeutils/visualize.py
+++ b/cmeutils/visualize.py
@@ -264,7 +264,7 @@ class FresnelGSD:
     def camera_position(self):
         """The camera position.
         Determined from box dimensions are FresnelGSD.view_axis"""
-        return (self.snapshot.configuration.box[:3] * self.view_axis) - 0.5
+        return (self.snapshot.configuration.box[:3] * self.view_axis) * 0.95
 
     @property
     def look_at(self):

--- a/cmeutils/visualize.py
+++ b/cmeutils/visualize.py
@@ -89,10 +89,10 @@ class FresnelGSD:
         self._specular = specular
         self._specular_trans = specular_trans
         self._metal = metal
-        # self._view_axis = np.asarray(view_axis)
         self._up = np.asarray(up)
         self._show_box = show_box
         self._box_radius = box_radius
+        self._height_factor = 1.25
 
     @property
     def frame(self):
@@ -379,7 +379,7 @@ class FresnelGSD:
             position=self.camera_position,
             look_at=self.look_at,
             up=self.up,
-            height=self.height,
+            height=self.height * self._height_factor,
         )
         return camera
 

--- a/cmeutils/visualize.py
+++ b/cmeutils/visualize.py
@@ -263,8 +263,8 @@ class FresnelGSD:
     @property
     def camera_position(self):
         """The camera position.
-        Determined from box dimensions are FresnelGSD.view_axis"""
-        return (self.snapshot.configuration.box[:3] * self.view_axis) * 0.95
+        Determined from box dimensions and FresnelGSD.view_axis"""
+        return self.snapshot.configuration.box[:3] * self.view_axis
 
     @property
     def look_at(self):


### PR DESCRIPTION
This PR adds a way to manually set colors besides using a dictionary with particle_type:color pairings.  For example, to set different colors for the first half and second half of particles by count:

Here is a quick example. It's from the welding tutorial in hoomd_organics:

```
sim_viewer = FresnelGSD(gsd_file="tensile.gsd", view_axis=(0, 1, 0), frame=-1, height=16)
weld_colors = np.zeros_like(sim_viewer.positions)
weld_colors[:weld_colors.shape[0]//2 + 1] = np.array([0.5, 0.25, 0.5])
weld_colors[weld_colors.shape[0]//2 + 1:] = np.array([0.5, 0.1, 0.1])
sim_viewer.colors = weld_colors
```

