### PR TITLE
Add structure factor wrapper

### DIFF
--- a/cmeutils/gsd_utils.py
+++ b/cmeutils/gsd_utils.py
@@ -10,7 +10,7 @@ from cmeutils.geometry import moit
 
 def frame_to_freud_system(frame, ref_length=None):
     """Creates a freud system given a gsd.hoomd.Frame.
-    
+
     Parameters
     ----------
     frame : gsd.hoomd.Frame, required

--- a/cmeutils/gsd_utils.py
+++ b/cmeutils/gsd_utils.py
@@ -8,10 +8,11 @@ import numpy as np
 from cmeutils.geometry import moit
 
 
-def snapshot_to_freud_system(snapshot, ref_distance):
-    box = snapshot.configuration.box
+def frame_to_freud_system(frame, ref_distance):
+    """Creates a freud system given a gsd.hoomd.Frame."""
+    box = frame.configuration.box
     box[0:3] *= ref_distance
-    xyz = snapshot.particles.position * ref_distance
+    xyz = frame.particles.position * ref_distance
     return freud.locality.NeighborQuery.from_system(system=(box, xyz))
 
 

--- a/cmeutils/gsd_utils.py
+++ b/cmeutils/gsd_utils.py
@@ -8,7 +8,7 @@ import numpy as np
 from cmeutils.geometry import moit
 
 
-def frame_to_freud_system(frame, ref_length):
+def frame_to_freud_system(frame, ref_length=None):
     """Creates a freud system given a gsd.hoomd.Frame.
     
     Parameters
@@ -19,6 +19,8 @@ def frame_to_freud_system(frame, ref_length):
         Set a reference length to convert from reduced units to real units.
         If None, uses 1 by default.
     """
+    if ref_length is None:
+        ref_length = 1
     box = frame.configuration.box
     box[0:3] *= ref_length
     xyz = frame.particles.position * ref_length

--- a/cmeutils/gsd_utils.py
+++ b/cmeutils/gsd_utils.py
@@ -8,6 +8,13 @@ import numpy as np
 from cmeutils.geometry import moit
 
 
+def snapshot_to_freud_system(snapshot, ref_distance):
+    box = snapshot.configuration.box
+    box[0:3] *= ref_distance
+    xyz = snapshot.particles.position * ref_distance
+    return freud.locality.NeighborQuery.from_system(system=(box, xyz))
+
+
 def get_type_position(
     typename, gsd_file=None, snap=None, gsd_frame=-1, images=False
 ):

--- a/cmeutils/gsd_utils.py
+++ b/cmeutils/gsd_utils.py
@@ -8,11 +8,20 @@ import numpy as np
 from cmeutils.geometry import moit
 
 
-def frame_to_freud_system(frame, ref_distance):
-    """Creates a freud system given a gsd.hoomd.Frame."""
+def frame_to_freud_system(frame, ref_length):
+    """Creates a freud system given a gsd.hoomd.Frame.
+    
+    Parameters
+    ----------
+    frame : gsd.hoomd.Frame, required
+        Frame used to get box and particle positions.
+    ref_length : float, optional, default None
+        Set a reference length to convert from reduced units to real units.
+        If None, uses 1 by default.
+    """
     box = frame.configuration.box
-    box[0:3] *= ref_distance
-    xyz = frame.particles.position * ref_distance
+    box[0:3] *= ref_length
+    xyz = frame.particles.position * ref_length
     return freud.locality.NeighborQuery.from_system(system=(box, xyz))
 
 

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -474,7 +474,7 @@ def structure_factor(
     stop=-1,
     bins=100,
     method="direct",
-    ref_distance=None,
+    ref_length=None,
 ):
     """
 
@@ -498,10 +498,13 @@ def structure_factor(
         Choose the method used by freud.
         Options are "direct" or "debye"
         See: https://freud.readthedocs.io/en/latest/modules/diffraction.html#freud.diffraction.StaticStructureFactorDirect # noqa: E501
+    ref_length : float, optional, default None
+        Set a reference length to convert from reduced units to real units.
+        If None, uses 1 by default.
 
     Returns
     -------
-    freud.diffraction.StatisStructureFactorDirect or
+    freud.diffraction.StaticStructureFactorDirect or
     freud.diffraction.StaticStructureFactorDebye
     """
 
@@ -517,13 +520,11 @@ def structure_factor(
         raise ValueError(
             f"Optional methods are `debye` or `direct`, you chose {method}"
         )
-    if not ref_distance:
-        ref_distance = 1
+    if not ref_length:
+        ref_length = 1
     with gsd.hoomd.open(gsdfile, mode="r") as trajectory:
         for frame in trajectory[start:stop]:
-            system = frame_to_freud_system(
-                frame=frame, ref_distance=ref_distance
-            )
+            system = frame_to_freud_system(frame=frame, ref_length=ref_length)
             sf.compute(system=system, reset=False)
     return sf
 

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -494,6 +494,8 @@ def structure_factor(
         will be used.
     bins : int, optional default 100
         Number of bins to use when calculating the Sq.
+        Used as the `bins` parameter in `StaticStructureFactorDirect` or
+        the `num_k_values` parameter in `StaticStructureFactorDebye`.
     method : str optional default "direct"
         Choose the method used by freud.
         Options are "direct" or "debye"
@@ -513,11 +515,13 @@ def structure_factor(
 
     if method.lower() == "direct":
         sf = freud.diffraction.StaticStructureFactorDirect(
-            bins=bins, k_max=k_max, k_min=k_min
+            bins=bins, k_max=k_max / ref_length, k_min=k_min / ref_length
         )
     elif method.lower() == "debye":
         sf = freud.diffraction.StaticStructureFactorDebye(
-            num_k_values=bins, k_max=k_max, k_min=k_min
+            num_k_values=bins,
+            k_max=k_max / ref_length,
+            k_min=k_min / ref_length,
         )
     else:
         raise ValueError(

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -6,12 +6,12 @@ import gsd.hoomd
 import numpy as np
 from rowan import vector_vector_rotation
 
-from cmeutils.gsd_utils import frame_to_freud_system, get_molecule_cluster
 from cmeutils.geometry import (
     angle_between_vectors,
     dihedral_angle,
     get_plane_normal,
 )
+from cmeutils.gsd_utils import frame_to_freud_system, get_molecule_cluster
 from cmeutils.plotting import get_histogram
 
 

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -6,11 +6,10 @@ import gsd.hoomd
 import numpy as np
 from rowan import vector_vector_rotation
 
-from cmeutils import gsd_utils
+from cmeutils.gsd_utils import frame_to_freud_system, get_molecule_cluster
 from cmeutils.geometry import (
     angle_between_vectors,
     dihedral_angle,
-    frame_to_freud_system,
     get_plane_normal,
 )
 from cmeutils.plotting import get_histogram
@@ -429,7 +428,7 @@ def gsd_rdf(
         type_B = snap.particles.typeid == snap.particles.types.index(B_name)
 
         if exclude_bonded:
-            molecules = gsd_utils.get_molecule_cluster(snap=snap)
+            molecules = get_molecule_cluster(snap=snap)
             molecules_A = molecules[type_A]
             molecules_B = molecules[type_B]
 
@@ -549,7 +548,7 @@ def get_centers(gsdfile, new_gsdfile):
         gsdfile, "r"
     ) as traj:
         snap = traj[0]
-        cluster_idx = gsd_utils.get_molecule_cluster(snap=snap)
+        cluster_idx = get_molecule_cluster(snap=snap)
         for snap in traj:
             new_snap = gsd.hoomd.Frame()
             new_snap.configuration.box = snap.configuration.box

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -541,6 +541,11 @@ def diffraction_pattern(
 ):
     """Uses freud's diffraction module to find 2D diffraction patterns.
 
+    Notes
+    -----
+    The diffraction pattern is averaged over both views and frames
+    set by the lenght of views and the range start - stop.
+
     Parameters
     ----------
     gsdfile : str, required
@@ -557,6 +562,10 @@ def diffraction_pattern(
     ref_length : float, optional, default None
         Set a reference length to convert from reduced units to real units.
         If None, uses 1 by default.
+    grid_size : unsigned int, optional, default 1024
+        Resolution of the diffraction grid.
+    output_size : unsigned int, optional, default None
+        Resolution of the output diffraction image.
 
     Returns
     -------

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -10,8 +10,8 @@ from cmeutils import gsd_utils
 from cmeutils.geometry import (
     angle_between_vectors,
     dihedral_angle,
+    frame_to_freud_system,
     get_plane_normal,
-    snapshot_to_freud_system,
 )
 from cmeutils.plotting import get_histogram
 
@@ -521,9 +521,9 @@ def structure_factor(
     if not ref_distance:
         ref_distance = 1
     with gsd.hoomd.open(gsdfile, mode="r") as trajectory:
-        for snap in trajectory[start:stop]:
-            system = snapshot_to_freud_system(
-                snapshot=snap, ref_distance=ref_distance
+        for frame in trajectory[start:stop]:
+            system = frame_to_freud_system(
+                frame=frame, ref_distance=ref_distance
             )
             sf.compute(system=system, reset=False)
     return sf

--- a/cmeutils/structure.py
+++ b/cmeutils/structure.py
@@ -548,7 +548,7 @@ def diffraction_pattern(
     Notes
     -----
     The diffraction pattern is averaged over both views and frames
-    set by the lenght of views and the range start - stop.
+    set by the length of views and the range start - stop.
 
     Parameters
     ----------

--- a/cmeutils/tests/test_gsd.py
+++ b/cmeutils/tests/test_gsd.py
@@ -1,3 +1,4 @@
+import freud
 import gsd.hoomd
 import mbuild as mb
 import numpy as np
@@ -16,6 +17,7 @@ from cmeutils.gsd_utils import (
     snap_delete_types,
     update_rigid_snapshot,
     xml_to_gsd,
+    frame_to_freud_system
 )
 
 try:
@@ -31,6 +33,12 @@ except ImportError:
 
 
 class TestGSD(BaseTest):
+    def test_frame_to_freud_system(self, butane_gsd):
+        with gsd.hoomd.open(butane_gsd) as traj:
+            frame = traj[0]
+        freud_sys = frame_to_freud_system(frame)
+        assert isinstance(freud_sys, freud.locality.NeighborQuery) 
+
     def test_ellipsoid_gsd(self, butane_gsd):
         ellipsoid_gsd(butane_gsd, "ellipsoid.gsd", 0.5, 1.0)
         with gsd.hoomd.open(name="ellipsoid.gsd", mode="r") as f:

--- a/cmeutils/tests/test_gsd.py
+++ b/cmeutils/tests/test_gsd.py
@@ -11,13 +11,13 @@ from cmeutils.gsd_utils import (
     _validate_inputs,
     create_rigid_snapshot,
     ellipsoid_gsd,
+    frame_to_freud_system,
     get_all_types,
     get_molecule_cluster,
     get_type_position,
     snap_delete_types,
     update_rigid_snapshot,
     xml_to_gsd,
-    frame_to_freud_system
 )
 
 try:
@@ -37,7 +37,7 @@ class TestGSD(BaseTest):
         with gsd.hoomd.open(butane_gsd) as traj:
             frame = traj[0]
         freud_sys = frame_to_freud_system(frame)
-        assert isinstance(freud_sys, freud.locality.NeighborQuery) 
+        assert isinstance(freud_sys, freud.locality.NeighborQuery)
 
     def test_ellipsoid_gsd(self, butane_gsd):
         ellipsoid_gsd(butane_gsd, "ellipsoid.gsd", 0.5, 1.0)

--- a/cmeutils/tests/test_structure.py
+++ b/cmeutils/tests/test_structure.py
@@ -12,6 +12,7 @@ from cmeutils.structure import (
     get_centers,
     get_quaternions,
     gsd_rdf,
+    structure_factor,
     order_parameter,
 )
 from cmeutils.tests.base_test import BaseTest
@@ -185,6 +186,14 @@ class TestStructure(BaseTest):
                 theta_min=120,
                 theta_max=180,
             )
+
+    def test_structure_factor_direct(self, gsdfile_bond):
+        sf = structure_factor(gsdfile_bond, k_min=0.2, k_max=5)
+        assert isinstance(sf, freud.diffraction.StaticStructureFactorDirect)
+
+    def test_structure_factor_debye(self, gsdfile_bond):
+        sf = structure_factor(gsdfile_bond, k_min=0.2, k_max=5, method="debye")
+        assert isinstance(sf, freud.diffraction.StaticStructureFactorDebye)
 
     def test_gsd_rdf(self, gsdfile_bond):
         rdf_ex, norm = gsd_rdf(gsdfile_bond, "A", "B")

--- a/cmeutils/tests/test_structure.py
+++ b/cmeutils/tests/test_structure.py
@@ -12,8 +12,8 @@ from cmeutils.structure import (
     get_centers,
     get_quaternions,
     gsd_rdf,
-    structure_factor,
     order_parameter,
+    structure_factor,
 )
 from cmeutils.tests.base_test import BaseTest
 

--- a/cmeutils/tests/test_structure.py
+++ b/cmeutils/tests/test_structure.py
@@ -8,6 +8,7 @@ from cmeutils.structure import (
     all_atom_rdf,
     angle_distribution,
     bond_distribution,
+    diffraction_pattern,
     dihedral_distribution,
     get_centers,
     get_quaternions,
@@ -186,6 +187,11 @@ class TestStructure(BaseTest):
                 theta_min=120,
                 theta_max=180,
             )
+
+    def test_diffraction_pattern(self, gsdfile_bond):
+        views = get_quaternions(n_views=5)
+        dp = diffraction_pattern(gsdfile_bond, views=views)
+        assert isinstance(dp, freud.diffraction.DiffractionPattern)
 
     def test_structure_factor_direct(self, gsdfile_bond):
         sf = structure_factor(gsdfile_bond, k_min=0.2, k_max=5)

--- a/cmeutils/tests/test_structure.py
+++ b/cmeutils/tests/test_structure.py
@@ -197,7 +197,7 @@ class TestStructure(BaseTest):
 
     def test_structure_factor_bad_method(self, gsdfile_bond):
         with pytest.raises(ValueError):
-            sf = structure_factor(gsdfile_bond, k_min=0.2, k_max=5, method="a")
+            structure_factor(gsdfile_bond, k_min=0.2, k_max=5, method="a")
 
     def test_gsd_rdf(self, gsdfile_bond):
         rdf_ex, norm = gsd_rdf(gsdfile_bond, "A", "B")

--- a/cmeutils/tests/test_structure.py
+++ b/cmeutils/tests/test_structure.py
@@ -195,6 +195,10 @@ class TestStructure(BaseTest):
         sf = structure_factor(gsdfile_bond, k_min=0.2, k_max=5, method="debye")
         assert isinstance(sf, freud.diffraction.StaticStructureFactorDebye)
 
+    def test_structure_factor_bad_method(self, gsdfile_bond):
+        with pytest.raises(ValueError):
+            sf = structure_factor(gsdfile_bond, k_min=0.2, k_max=5, method="a")
+
     def test_gsd_rdf(self, gsdfile_bond):
         rdf_ex, norm = gsd_rdf(gsdfile_bond, "A", "B")
         rdf_noex, norm2 = gsd_rdf(gsdfile_bond, "A", "B", exclude_bonded=False)


### PR DESCRIPTION
This PR adds a function that acts as a wrapper for freud's [1D structure factor objects](https://freud.readthedocs.io/en/latest/modules/diffraction.html). It basically follows the same structure/format as the `gsd_rdf` function.

