### PR TITLE
update to hoomd4, fix rigid body stuff

### DIFF
--- a/cmeutils/gsd_utils.py
+++ b/cmeutils/gsd_utils.py
@@ -295,15 +295,11 @@ def update_rigid_snapshot(snapshot, mb_compound):
         snapshot.particles.types[i] for i in snapshot.particles.typeid[inds]
     ]
     c_orient = [tuple(i) for i in snapshot.particles.orientation[inds]]
-    c_charge = [i for i in snapshot.particles.charge[inds]]
-    c_diam = [i for i in snapshot.particles.diameter[inds]]
 
     rigid.body["R"] = {
         "constituent_types": c_types,
         "positions": c_pos,
-        "charges": c_charge,
         "orientations": c_orient,
-        "diameters": c_diam,
     }
     return snapshot, rigid
 

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -4,8 +4,8 @@ channels:
 dependencies:
   - freud >=2.13.1
   - fresnel >=0.13.5
-  - gsd >=2.9
-  - hoomd >=4.0=*cpu*
+  - gsd >=3.0
+  - hoomd >=4.0
   - mbuild >=0.16.4
   - numpy
   - pip

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -2,14 +2,14 @@ name: cmeutils-dev
 channels:
   - conda-forge
 dependencies:
-  - fresnel
-  - freud>=2.13.1
-  - gsd>=3.0
-  - hoomd<4.0=*cpu*
-  - mbuild
+  - freud >=2.13.1
+  - fresnel >=0.13.5
+  - gsd >=2.9
+  - hoomd >=4.0=*cpu*
+  - mbuild >=0.16.4
   - numpy
   - pip
-  - python
+  - python >= 3.10
   - matplotlib
   - pre-commit
   - pymbar >= 4.0

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - freud >=2.13.1
   - fresnel >=0.13.5
-  - gsd >=2.9
+  - gsd >=3.0
   - hoomd >=4.0
   - mbuild >=0.16.4
   - numpy

--- a/environment.yml
+++ b/environment.yml
@@ -2,14 +2,14 @@ name: cmeutils
 channels:
   - conda-forge
 dependencies:
-  - fresnel
-  - freud>=2.13.1
-  - gsd>=3.0
-  - hoomd<4.0=*cpu*
-  - mbuild
+  - freud >=2.13.1
+  - fresnel >=0.13.5
+  - gsd >=2.9
+  - hoomd >=4.0=*cpu*
+  - mbuild >=0.16.4
   - numpy
   - pip
-  - python
+  - python >= 3.10
   - matplotlib
   - pymbar >= 4.0
   - rowan

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - freud >=2.13.1
   - fresnel >=0.13.5
   - gsd >=2.9
-  - hoomd >=4.0=*cpu*
+  - hoomd >=4.0
   - mbuild >=0.16.4
   - numpy
   - pip


### PR DESCRIPTION
This PR updates the environment yaml files to use hoomd >= 4.0 so that it is compatible with `flowermd` when installing from conda. Because of this, a couple properties were removed from setting up rigid bodies (charges and diameter).