### PR TITLE
Update installation instructions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@
 
 Helpful functions used by the [CME Lab](https://www.boisestate.edu/coen-cmelab/).
 
-### Installation
+## Installation
 Installation of CME Lab Utilities requires a conda package manager. We recommend [Miniconda](https://docs.conda.io/en/latest/miniconda.html).
 
-## Installing from conda-forge:
+### Installing from conda-forge:
 1. Create a new conda environment and install `cmeutils`
 	````
 	conda create -n cmeutils -c conda-forge cmeutils
 	conda activate cmeutils
 	```
 
-## Installing from source (for development):
+### Installing from source (for development):
 1. Clone this repository:
     ```
     git clone git@github.com:cmelab/cmeutils.git

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Helpful functions used by the [CME Lab](https://www.boisestate.edu/coen-cmelab/)
 Installation of CME Lab Utilities requires a conda package manager. We recommend [Miniconda](https://docs.conda.io/en/latest/miniconda.html).
 
 ### Installing from conda-forge:
-1. Create a new conda environment and install `cmeutils`
-	````
+1. Create a new conda environment and install cmeutils.
+	```
 	conda create -n cmeutils -c conda-forge cmeutils
 	conda activate cmeutils
 	```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,16 @@
 Helpful functions used by the [CME Lab](https://www.boisestate.edu/coen-cmelab/).
 
 ### Installation
-Installation of CME Lab Utilities requires the conda package manager. We recommend [Miniconda](https://docs.conda.io/en/latest/miniconda.html).
+Installation of CME Lab Utilities requires a conda package manager. We recommend [Miniconda](https://docs.conda.io/en/latest/miniconda.html).
+
+## Installing from conda-forge:
+1. Create a new conda environment and install `cmeutils`
+	````
+	conda create -n cmeutils -c conda-forge cmeutils
+	conda activate cmeutils
+	```
+
+## Installing from source (for development):
 1. Clone this repository:
     ```
     git clone git@github.com:cmelab/cmeutils.git
@@ -18,8 +27,7 @@ Installation of CME Lab Utilities requires the conda package manager. We recomme
     conda env create -f environment.yml
     conda activate cmeutils
     ```
-3. Install this package with pip:
-
+3. Install from source with pip:
     ```
-    pip install .
+    pip install -e .
     ```


### PR DESCRIPTION
Now that the conda-forge package has been updated with all of the recent development added, the installation instructions start with installing cmeutils from `conda-forge`.