### PR TITLE
Fix error in `get_backbone_vector`

### DIFF
--- a/cmeutils/geometry.py
+++ b/cmeutils/geometry.py
@@ -26,7 +26,7 @@ def get_backbone_vector(coordinates):
     _, _, V = np.linalg.svd(centered_coordinates)
     # The first principal component (V[0]) is the vec of the best-fit line
     direction_vector = V[0]
-    return np.abs(direction_vector)
+    return direction_vector
 
 
 def get_plane_normal(points):

--- a/cmeutils/tests/test_geometry.py
+++ b/cmeutils/tests/test_geometry.py
@@ -19,15 +19,15 @@ class TestGeometry(BaseTest):
     def test_backbone_vector(self):
         z_coords = np.array([[0, 0, 1], [0, 0, 2], [0, 0, 3]])
         backbone = get_backbone_vector(z_coords)
-        assert np.allclose(backbone, np.array([0, 0, 1]), atol=1e-5)
+        assert np.allclose(np.abs(backbone), np.array([0, 0, 1]), atol=1e-5)
 
         x_coords = np.array([[1, 0, 0], [2, 0, 0], [3, 0, 0]])
         backbone = get_backbone_vector(x_coords)
-        assert np.allclose(backbone, np.array([1, 0, 0]), atol=1e-5)
+        assert np.allclose(np.abs(backbone), np.array([1, 0, 0]), atol=1e-5)
 
         mb_chain = Alkane(n=20)
-        chain_backbone = get_backbone_vector(mb_chain.xyz)
-        assert np.allclose(chain_backbone, np.array([0, 1, 0]), atol=1e-2)
+        backbone = get_backbone_vector(mb_chain.xyz)
+        assert np.allclose(np.abs(backbone), np.array([0, 1, 0]), atol=1e-2)
 
     def test_backbone_vector_bad_input(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
I made a last second change that returned the absolute value of the vector, but that broke the expected behavior in `flowermd`. I don't think it is really necessary to return the absolute value. 