### PR TITLE
Move hoomd import inside rigid body function

### DIFF
--- a/cmeutils/gsd_utils.py
+++ b/cmeutils/gsd_utils.py
@@ -3,7 +3,6 @@ from tempfile import NamedTemporaryFile
 
 import freud
 import gsd.hoomd
-import hoomd
 import networkx as nx
 import numpy as np
 from boltons.setutils import IndexedSet
@@ -255,6 +254,8 @@ def update_rigid_snapshot(snapshot, mb_compound):
         of the complete system
 
     """
+    import hoomd
+
     rigid_ids = [p.rigid_id for p in mb_compound.particles()]
     rigid_bodies = set(rigid_ids)
     # Total number of rigid body particles


### PR DESCRIPTION
This is a small change that moves the hoomd import from the top of `gsd_utils.py` into the `create_rigid_snapshot` method, which is the only place it is used. 

Importing and using other cmeutils methods was causing issues on clusters when my environment had the gpu-version of hoomd, but the job wasn't on a gpu node.