### PR TITLE
Pin freud to v2.13.2 in environment files.

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -2,7 +2,7 @@ name: cmeutils-dev
 channels:
   - conda-forge
 dependencies:
-  - freud >=2.13.1
+  - freud =2.13.2
   - gmso >=0.11.2
   - fresnel >=0.13.5
   - gsd >=3.0

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: cmeutils
 channels:
   - conda-forge
 dependencies:
-  - freud >=2.13.1
+  - freud =2.13.2
   - gmso >=0.11.2
   - fresnel >=0.13.5
   - gsd >=3.0


### PR DESCRIPTION
Related to #81. We can pin to 2.13.2 until we fix the breaking changes. [A PR to the feedstock](https://github.com/conda-forge/cmeutils-feedstock/pull/14l) is open which pins the version on conda-forge as well.