### PR TITLE
Add helper function to generate stress vs strain data from a flowerMD tensile test simulation

### DIFF
--- a/cmeutils/dynamics.py
+++ b/cmeutils/dynamics.py
@@ -8,6 +8,24 @@ import numpy as np
 from cmeutils import gsd_utils
 
 
+def tensile_test(gsd_file, period, tensile_axis, ref_energy=1, ref_distance=1):
+    # Get initial box info and initial stress average
+    tensor_index_map = {0: 0, 1: 3, 2: 5}
+    with gsd.hoomd.open(gsd_file) as traj:
+        n_frames = len(traj)
+        # init_snap = traj[0]
+        # init_length = init_snap.configuration.box[tensile_axis]
+        # Store relevant stress tensor value for each frame
+        frame_stress_data = np.zeros(n_frames)
+        for idx, snap in enumerate(traj):
+            frame_stress_data[idx] = snap.log[
+                "md/compute/ThermodynamicQuantities/pressure_tensor"
+            ][tensor_index_map[tensile_axis]]
+
+    # window_means = np.zeros(n_frames // period)
+    # window_stds = np.zeros(n_frames // period)
+
+
 def msd_from_gsd(
     gsdfile, atom_types="all", start=0, stop=-1, msd_mode="window"
 ):

--- a/cmeutils/dynamics.py
+++ b/cmeutils/dynamics.py
@@ -34,10 +34,10 @@ def tensile_test(
 
     # Perform stress sampling
     box_lengths = np.unique(frame_box_data)
-    strain = np.zeros(len(box_lengths))
-    window_means = np.zeros(len(box_lengths))
-    window_stds = np.zeros(len(box_lengths))
-    window_sems = np.zeros(len(box_lengths))
+    strain = np.zeros_like(box_lengths, dtype=float)
+    window_means = np.zeros_like(box_lengths, dtype=float)
+    window_stds = np.zeros_like(box_lengths, dtype=float)
+    window_sems = np.zeros_like(box_lengths, dtype=float)
     if ref_energy and ref_distance:
         conv_factor = ref_energy.to("J/mol") / (ref_distance.to("m")**3 * u.Avogadros_number_mks)
         conv_factor *= 1e-6
@@ -58,7 +58,6 @@ def tensile_test(
         window_means[idx] = avg_stress
         window_stds[idx] = std_stress
         window_sems[idx] = sem_stress
-
 
     return strain, -window_means, window_stds, window_sems
 

--- a/cmeutils/dynamics.py
+++ b/cmeutils/dynamics.py
@@ -65,18 +65,18 @@ def tensile_test(
         indices = np.where(frame_box_data == box_length)[0]
         stress = frame_stress_data[indices] * conv_factor
         if bootstrap_sampling:
-            bootstrap_means = []
-            n_data_points = len(strain)
+            n_data_points = len(stress)
             n_samples = 5
             window_size = n_data_points // 5
+            bootstrap_means = []
             for i in range(n_samples):
                 start = np.random.randint(
                     low=0, high=(n_data_points - window_size)
                 )
-                window_sample = strain[
+                window_sample = stress[
                     start : start + window_size  # noqa: E203
                 ]
-                bootstrap_means.append(window_sample)
+                bootstrap_means.append(np.mean(window_sample))
             avg_stress = np.mean(bootstrap_means)
             std_stress = np.std(bootstrap_means)
             sem_stress = scipy.stats.sem(bootstrap_means)


### PR DESCRIPTION
This PR adds a function that can be used to plot stress vs strain data, and to get a Young's Modulus. I'm still a bit unsure how to best handle the averaging/sampling if the tensile test simulation involves running fo some period between box updates. 

Right now, the options are to sample stress from the last half of the period, or to try some boot-strap sampling from the period.

I'm not saying either of these are correct, but I wanted to open this PR to begin a discussion on how to best get pressure/stress averages from tensile test simulations. 