### PR TITLE
correct ellipsoid axes in gsd visualization function

### DIFF
--- a/cmeutils/gsd_utils.py
+++ b/cmeutils/gsd_utils.py
@@ -244,9 +244,9 @@ def ellipsoid_gsd(gsd_file, new_file, ellipsoid_types, lpar, lperp):
                     if ptype == ellipsoid_types or ptype in ellipsoid_types:
                         shapes_dict = {
                             "type": "Ellipsoid",
-                            "a": lpar,
+                            "a": lperp,
                             "b": lperp,
-                            "c": lperp,
+                            "c": lpar,
                         }
                     else:
                         shapes_dict = {"type": "Sphere", "diameter": 0.001}


### PR DESCRIPTION
As per https://hoomd-blue.readthedocs.io/en/v5.3.0/hoomd/md/pair/aniso/gayberne.html, "The parallel direction is aligned with z axis in the particle’s reference frame." Also, according to https://gsd.readthedocs.io/en/v4.0.0/shapes.html#ellipsoids, the `c` parameter is the radius in the z direction, so the current behavior displays ellipsoids rotated from where they should be.