### PR TITLE
Pin numpy >= 2.0, add python 3.13 to testing, pin freud to avoid MSD bug

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest]
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     runs-on: ${{ matrix.os }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
-        exclude: 'grits/tests/assets/.*'
+        exclude: 'cmeutils/tests/assets/.*'
   - repo: https://github.com/pycqa/isort
     rev: 6.0.1
     hooks:
@@ -29,4 +29,4 @@ repos:
         name: isort (python)
         args:
           [ --profile=black, --line-length=80 ]
-        exclude: 'grits/tests/assets/.* '
+        exclude: 'cmeutils/tests/assets/.* '

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -2,15 +2,15 @@ name: cmeutils-dev
 channels:
   - conda-forge
 dependencies:
-  - freud >= 3.0,<3.2
-  - gmso >=0.11.2
+  - freud>=3.4
+  - gmso >=0.14.0
   - fresnel >=0.13.5
   - gsd >=3.0
-  - hoomd >=4.0
-  - mbuild >=0.16.4
-  - numpy
+  - hoomd >=5.0
+  - mbuild >=1.0
+  - numpy >=2.0,<2.3
   - pip
-  - python >= 3.10,<=3.12
+  - python >= 3.10,<=3.13
   - matplotlib
   - pre-commit
   - pymbar >= 4.0

--- a/environment.yml
+++ b/environment.yml
@@ -1,16 +1,16 @@
-name: cmeutils
+name: cmeutils-dev
 channels:
   - conda-forge
 dependencies:
-  - freud >= 3.0,<3.2
-  - gmso >=0.11.2
+  - freud>=3.4
+  - gmso >=0.14.0
   - fresnel >=0.13.5
   - gsd >=3.0
-  - hoomd >=4.0
-  - mbuild >=0.16.4
-  - numpy
+  - hoomd >=5.0
+  - mbuild >=1.0
+  - numpy >=2.0,<2.3
   - pip
-  - python >= 3.10,<=3.12
+  - python >= 3.10,<=3.13
   - matplotlib
   - pymbar >= 4.0
   - rowan

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: cmeutils-dev
+name: cmeutils
 channels:
   - conda-forge
 dependencies:


### PR DESCRIPTION
This PR adds python 3.13 to the environment files and the CI testing, and pins numpy to >=2.0. This also pins freud to the latest released version after [finding a bug in their MSD module](https://github.com/glotzerlab/freud/issues/1342). This fixes #104 